### PR TITLE
feat(backend): Issue #8 — Payroll Calculator, Jobs & PDF Slip

### DIFF
--- a/backend/app/Http/Controllers/PayrollController.php
+++ b/backend/app/Http/Controllers/PayrollController.php
@@ -24,9 +24,14 @@ class PayrollController extends Controller
     {
         $entityId = $request->attributes->get('active_entity_id');
 
-        $query = PayrollRun::where('entity_id', $entityId)
+        $query = PayrollRun::query()
             ->orderByDesc('period_year')
             ->orderByDesc('period_month');
+
+        if ($entityId) {
+            $query->where('entity_id', $entityId);
+        }
+        // If $entityId is null (super_admin), no entity filter → returns all entities
 
         if ($year = $request->query('year')) {
             $query->where('period_year', (int) $year);
@@ -50,19 +55,29 @@ class PayrollController extends Controller
      */
     public function store(Request $request): JsonResponse
     {
+        $entityId = $request->attributes->get('active_entity_id');
+
         try {
-            $validated = $request->validate([
+            $rules = [
                 'period_month' => ['required', 'integer', 'min:1', 'max:12'],
                 'period_year'  => ['required', 'integer', 'min:' . (now()->year - 1), 'max:' . (now()->year + 1)],
-            ]);
+            ];
+
+            // super_admin is not scoped to an entity, so they must supply one explicitly
+            if (! $entityId) {
+                $rules['entity_id'] = ['required', 'uuid', 'exists:entities,id'];
+            }
+
+            $validated = $request->validate($rules);
         } catch (ValidationException $e) {
             return $this->error('Data tidak valid.', 422, $e->errors());
         }
 
-        $entityId = $request->attributes->get('active_entity_id');
+        // Resolve the entity to write: prefer explicit body value (super_admin path), else middleware-scoped value
+        $resolvedEntityId = $entityId ?? $validated['entity_id'];
 
         // Check for duplicate run in the same entity + period
-        $existing = PayrollRun::where('entity_id', $entityId)
+        $existing = PayrollRun::where('entity_id', $resolvedEntityId)
             ->where('period_month', $validated['period_month'])
             ->where('period_year', $validated['period_year'])
             ->first();
@@ -76,7 +91,7 @@ class PayrollController extends Controller
         }
 
         $run = PayrollRun::create([
-            'entity_id'    => $entityId,
+            'entity_id'    => $resolvedEntityId,
             'period_month' => $validated['period_month'],
             'period_year'  => $validated['period_year'],
             'status'       => 'DRAFT',
@@ -90,10 +105,13 @@ class PayrollController extends Controller
      */
     public function show(Request $request, string $run): JsonResponse
     {
-        $entityId   = $request->attributes->get('active_entity_id');
-        $payrollRun = PayrollRun::where('id', $run)
-            ->where('entity_id', $entityId)
-            ->first();
+        $entityId = $request->attributes->get('active_entity_id');
+
+        $query = PayrollRun::where('id', $run);
+        if ($entityId) {
+            $query->where('entity_id', $entityId);
+        }
+        $payrollRun = $query->first();
 
         if (! $payrollRun) {
             return $this->error('Payroll run tidak ditemukan.', 404);
@@ -107,10 +125,13 @@ class PayrollController extends Controller
      */
     public function process(Request $request, string $run): JsonResponse
     {
-        $entityId   = $request->attributes->get('active_entity_id');
-        $payrollRun = PayrollRun::where('id', $run)
-            ->where('entity_id', $entityId)
-            ->first();
+        $entityId = $request->attributes->get('active_entity_id');
+
+        $query = PayrollRun::where('id', $run);
+        if ($entityId) {
+            $query->where('entity_id', $entityId);
+        }
+        $payrollRun = $query->first();
 
         if (! $payrollRun) {
             return $this->error('Payroll run tidak ditemukan.', 404);
@@ -128,7 +149,8 @@ class PayrollController extends Controller
 
         return $this->success(
             ['run_id' => $payrollRun->id, 'status' => 'processing'],
-            'Proses kalkulasi payroll telah dimulai. Hasil akan tersedia segera.'
+            'Kalkulasi payroll sedang diproses.',
+            202
         );
     }
 
@@ -137,10 +159,13 @@ class PayrollController extends Controller
      */
     public function lock(Request $request, string $run): JsonResponse
     {
-        $entityId   = $request->attributes->get('active_entity_id');
-        $payrollRun = PayrollRun::where('id', $run)
-            ->where('entity_id', $entityId)
-            ->first();
+        $entityId = $request->attributes->get('active_entity_id');
+
+        $query = PayrollRun::where('id', $run);
+        if ($entityId) {
+            $query->where('entity_id', $entityId);
+        }
+        $payrollRun = $query->first();
 
         if (! $payrollRun) {
             return $this->error('Payroll run tidak ditemukan.', 404);
@@ -169,10 +194,13 @@ class PayrollController extends Controller
      */
     public function items(Request $request, string $run): JsonResponse
     {
-        $entityId   = $request->attributes->get('active_entity_id');
-        $payrollRun = PayrollRun::where('id', $run)
-            ->where('entity_id', $entityId)
-            ->first();
+        $entityId = $request->attributes->get('active_entity_id');
+
+        $runQuery = PayrollRun::where('id', $run);
+        if ($entityId) {
+            $runQuery->where('entity_id', $entityId);
+        }
+        $payrollRun = $runQuery->first();
 
         if (! $payrollRun) {
             return $this->error('Payroll run tidak ditemukan.', 404);
@@ -224,13 +252,13 @@ class PayrollController extends Controller
 
         $employment = $payrollItem->employment;
 
-        // Verify item belongs to the active entity
-        if (! $employment || $employment->entity_id !== $entityId) {
+        // Verify item belongs to the active entity (skip check for super_admin with no entity scope)
+        if (! $employment || ($entityId && $employment->entity_id !== $entityId)) {
             return $this->error('Akses ditolak.', 403);
         }
 
         // If the requester is an employee (not an admin), restrict to own slip
-        $isAdmin = $authUser->hasRole(['super_admin', 'entity_admin', 'hr_staff']);
+        $isAdmin = $authUser->hasRole(['super_admin', 'entity_admin']);
 
         if (! $isAdmin) {
             // Resolve the user's employment in this entity and compare
@@ -263,11 +291,12 @@ class PayrollController extends Controller
 
         $employment = $payrollItem->employment;
 
-        if (! $employment || $employment->entity_id !== $entityId) {
+        // Verify item belongs to the active entity (skip check for super_admin with no entity scope)
+        if (! $employment || ($entityId && $employment->entity_id !== $entityId)) {
             return $this->error('Akses ditolak.', 403);
         }
 
-        $isAdmin = $authUser->hasRole(['super_admin', 'entity_admin', 'hr_staff']);
+        $isAdmin = $authUser->hasRole(['super_admin', 'entity_admin']);
 
         if (! $isAdmin) {
             $userEmploymentIds = Employment::where('user_id', $authUser->id)
@@ -279,14 +308,25 @@ class PayrollController extends Controller
             }
         }
 
-        $path = $payrollItem->slip_url;
+        $slipPath = $payrollItem->slip_url;
 
-        if (! Storage::disk('local')->exists($path)) {
+        // Validate path stays within the slip storage directory
+        $allowedPrefix = 'slips/';
+        if (! $slipPath || ! str_starts_with($slipPath, $allowedPrefix)) {
+            return $this->error('Slip tidak tersedia.', 404);
+        }
+
+        // Reject directory traversal sequences
+        if (str_contains($slipPath, '..') || str_contains($slipPath, "\0")) {
+            return $this->error('Path tidak valid.', 400);
+        }
+
+        if (! Storage::disk('local')->exists($slipPath)) {
             return $this->error('File slip tidak ditemukan.', 404);
         }
 
         return Storage::disk('local')->download(
-            $path,
+            $slipPath,
             "slip-gaji-{$payrollItem->payrollRun?->period_year}-{$payrollItem->payrollRun?->period_month}.pdf",
             ['Content-Type' => 'application/pdf']
         );

--- a/backend/app/Http/Controllers/PayrollController.php
+++ b/backend/app/Http/Controllers/PayrollController.php
@@ -2,72 +2,237 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Resources\PayrollItemResource;
+use App\Http\Resources\PayrollRunResource;
+use App\Jobs\ProcessPayrollJob;
+use App\Models\Employment;
+use App\Models\PayrollItem;
+use App\Models\PayrollRun;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
 
 class PayrollController extends Controller
 {
     /**
-     * List all payroll runs for the active entity.
-     * Full implementation: Issue #6
+     * List payroll runs for the active entity, paginated 15/page.
+     * Optional filter: ?year=YYYY
      */
     public function index(Request $request): JsonResponse
     {
-        return $this->success([], 'Coming soon', 501);
+        $entityId = $request->attributes->get('active_entity_id');
+
+        $query = PayrollRun::where('entity_id', $entityId)
+            ->orderByDesc('period_year')
+            ->orderByDesc('period_month');
+
+        if ($year = $request->query('year')) {
+            $query->where('period_year', (int) $year);
+        }
+
+        $runs = $query->paginate(15);
+
+        return $this->success([
+            'data'       => PayrollRunResource::collection($runs->items()),
+            'pagination' => [
+                'current_page' => $runs->currentPage(),
+                'last_page'    => $runs->lastPage(),
+                'per_page'     => $runs->perPage(),
+                'total'        => $runs->total(),
+            ],
+        ]);
     }
 
     /**
-     * Create a new payroll run.
-     * Full implementation: Issue #6
+     * Create a new DRAFT payroll run.
      */
     public function store(Request $request): JsonResponse
     {
-        return $this->success([], 'Coming soon', 501);
+        try {
+            $validated = $request->validate([
+                'period_month' => ['required', 'integer', 'min:1', 'max:12'],
+                'period_year'  => ['required', 'integer', 'min:' . (now()->year - 1), 'max:' . (now()->year + 1)],
+            ]);
+        } catch (ValidationException $e) {
+            return $this->error('Data tidak valid.', 422, $e->errors());
+        }
+
+        $entityId = $request->attributes->get('active_entity_id');
+
+        // Check for duplicate run in the same entity + period
+        $existing = PayrollRun::where('entity_id', $entityId)
+            ->where('period_month', $validated['period_month'])
+            ->where('period_year', $validated['period_year'])
+            ->first();
+
+        if ($existing) {
+            return $this->error(
+                'Payroll run untuk periode ini sudah ada.',
+                409,
+                ['period' => ['Periode ' . $validated['period_month'] . '/' . $validated['period_year'] . ' sudah dibuat.']]
+            );
+        }
+
+        $run = PayrollRun::create([
+            'entity_id'    => $entityId,
+            'period_month' => $validated['period_month'],
+            'period_year'  => $validated['period_year'],
+            'status'       => 'DRAFT',
+        ]);
+
+        return $this->success(new PayrollRunResource($run), 'Payroll run berhasil dibuat.', 201);
     }
 
     /**
-     * Display a single payroll run summary.
-     * Full implementation: Issue #6
+     * Return a single payroll run with summary stats.
      */
     public function show(Request $request, string $run): JsonResponse
     {
-        return $this->success([], 'Coming soon', 501);
+        $entityId   = $request->attributes->get('active_entity_id');
+        $payrollRun = PayrollRun::where('id', $run)
+            ->where('entity_id', $entityId)
+            ->first();
+
+        if (! $payrollRun) {
+            return $this->error('Payroll run tidak ditemukan.', 404);
+        }
+
+        return $this->success(new PayrollRunResource($payrollRun));
     }
 
     /**
-     * Execute the payroll calculation for a run.
-     * Full implementation: Issue #6
+     * Dispatch the ProcessPayrollJob for a DRAFT run and return immediately.
      */
     public function process(Request $request, string $run): JsonResponse
     {
-        return $this->success([], 'Coming soon', 501);
+        $entityId   = $request->attributes->get('active_entity_id');
+        $payrollRun = PayrollRun::where('id', $run)
+            ->where('entity_id', $entityId)
+            ->first();
+
+        if (! $payrollRun) {
+            return $this->error('Payroll run tidak ditemukan.', 404);
+        }
+
+        if ($payrollRun->status !== 'DRAFT') {
+            return $this->error(
+                'Hanya payroll run berstatus DRAFT yang dapat diproses.',
+                422,
+                ['status' => ['Status saat ini: ' . $payrollRun->status]]
+            );
+        }
+
+        ProcessPayrollJob::dispatch($payrollRun->id, $request->user()?->id);
+
+        return $this->success(
+            ['run_id' => $payrollRun->id, 'status' => 'processing'],
+            'Proses kalkulasi payroll telah dimulai. Hasil akan tersedia segera.'
+        );
     }
 
     /**
-     * Lock a processed payroll run to prevent further changes.
-     * Full implementation: Issue #6
+     * Lock a PROCESSED run — set status to PAID.
      */
     public function lock(Request $request, string $run): JsonResponse
     {
-        return $this->success([], 'Coming soon', 501);
+        $entityId   = $request->attributes->get('active_entity_id');
+        $payrollRun = PayrollRun::where('id', $run)
+            ->where('entity_id', $entityId)
+            ->first();
+
+        if (! $payrollRun) {
+            return $this->error('Payroll run tidak ditemukan.', 404);
+        }
+
+        if ($payrollRun->status !== 'PROCESSED') {
+            return $this->error(
+                'Hanya payroll run berstatus PROCESSED yang dapat dikunci.',
+                422,
+                ['status' => ['Status saat ini: ' . $payrollRun->status]]
+            );
+        }
+
+        $payrollRun->update([
+            'status'     => 'PAID',
+            'locked_by'  => $request->user()?->id,
+            'locked_at'  => now(),
+        ]);
+
+        return $this->success(new PayrollRunResource($payrollRun), 'Payroll run telah dikunci (PAID).');
     }
 
     /**
-     * List individual payroll items within a run.
-     * Full implementation: Issue #6
+     * List payroll items for a run, with employment.user loaded.
+     * Optional filter: ?department=
      */
     public function items(Request $request, string $run): JsonResponse
     {
-        return $this->success([], 'Coming soon', 501);
+        $entityId   = $request->attributes->get('active_entity_id');
+        $payrollRun = PayrollRun::where('id', $run)
+            ->where('entity_id', $entityId)
+            ->first();
+
+        if (! $payrollRun) {
+            return $this->error('Payroll run tidak ditemukan.', 404);
+        }
+
+        $query = PayrollItem::with(['employment.user'])
+            ->where('payroll_run_id', $payrollRun->id);
+
+        // Filter by department via the employment relation
+        if ($department = $request->query('department')) {
+            $query->whereHas('employment', function ($q) use ($department) {
+                $q->where('department', $department);
+            });
+        }
+
+        $items = $query->get();
+
+        return $this->success(PayrollItemResource::collection($items));
     }
 
     /**
-     * Return the pay slip for a single payroll item.
-     * Controller validates ownership before returning data.
-     * Full implementation: Issue #6
+     * Return the pay slip data for a single payroll item.
+     *
+     * - Employee: may only view their own slip.
+     * - Admin/HR: may view any slip within their active entity.
      */
     public function slip(Request $request, string $item): JsonResponse
     {
-        return $this->success([], 'Coming soon', 501);
+        $entityId    = $request->attributes->get('active_entity_id');
+        $authUser    = $request->user();
+
+        $payrollItem = PayrollItem::with([
+            'employment.user',
+            'employment.entity',
+            'payrollRun',
+        ])->find($item);
+
+        if (! $payrollItem) {
+            return $this->error('Payroll item tidak ditemukan.', 404);
+        }
+
+        $employment = $payrollItem->employment;
+
+        // Verify item belongs to the active entity
+        if (! $employment || $employment->entity_id !== $entityId) {
+            return $this->error('Akses ditolak.', 403);
+        }
+
+        // If the requester is an employee (not an admin), restrict to own slip
+        $isAdmin = $authUser->hasRole(['super_admin', 'entity_admin', 'hr_staff']);
+
+        if (! $isAdmin) {
+            // Resolve the user's employment in this entity and compare
+            $userEmploymentIds = Employment::where('user_id', $authUser->id)
+                ->where('entity_id', $entityId)
+                ->pluck('id');
+
+            if (! $userEmploymentIds->contains($employment->id)) {
+                return $this->error('Anda hanya dapat melihat slip gaji milik Anda sendiri.', 403);
+            }
+        }
+
+        return $this->success(new PayrollItemResource($payrollItem));
     }
 }

--- a/backend/app/Http/Controllers/PayrollController.php
+++ b/backend/app/Http/Controllers/PayrollController.php
@@ -10,7 +10,9 @@ use App\Models\PayrollItem;
 use App\Models\PayrollRun;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class PayrollController extends Controller
 {
@@ -186,9 +188,17 @@ class PayrollController extends Controller
             });
         }
 
-        $items = $query->get();
+        $paginator = $query->paginate(50);
 
-        return $this->success(PayrollItemResource::collection($items));
+        return $this->success([
+            'data'       => PayrollItemResource::collection($paginator->items()),
+            'pagination' => [
+                'current_page' => $paginator->currentPage(),
+                'last_page'    => $paginator->lastPage(),
+                'per_page'     => $paginator->perPage(),
+                'total'        => $paginator->total(),
+            ],
+        ]);
     }
 
     /**
@@ -234,5 +244,51 @@ class PayrollController extends Controller
         }
 
         return $this->success(new PayrollItemResource($payrollItem));
+    }
+
+    /**
+     * Stream the PDF slip file from local (private) storage.
+     * Uses same ownership checks as slip().
+     */
+    public function downloadSlip(Request $request, string $item): StreamedResponse|JsonResponse
+    {
+        $entityId = $request->attributes->get('active_entity_id');
+        $authUser = $request->user();
+
+        $payrollItem = PayrollItem::with(['employment', 'payrollRun'])->find($item);
+
+        if (! $payrollItem || ! $payrollItem->slip_url) {
+            return $this->error('Slip gaji belum tersedia.', 404);
+        }
+
+        $employment = $payrollItem->employment;
+
+        if (! $employment || $employment->entity_id !== $entityId) {
+            return $this->error('Akses ditolak.', 403);
+        }
+
+        $isAdmin = $authUser->hasRole(['super_admin', 'entity_admin', 'hr_staff']);
+
+        if (! $isAdmin) {
+            $userEmploymentIds = Employment::where('user_id', $authUser->id)
+                ->where('entity_id', $entityId)
+                ->pluck('id');
+
+            if (! $userEmploymentIds->contains($employment->id)) {
+                return $this->error('Anda hanya dapat mengunduh slip gaji milik Anda sendiri.', 403);
+            }
+        }
+
+        $path = $payrollItem->slip_url;
+
+        if (! Storage::disk('local')->exists($path)) {
+            return $this->error('File slip tidak ditemukan.', 404);
+        }
+
+        return Storage::disk('local')->download(
+            $path,
+            "slip-gaji-{$payrollItem->payrollRun?->period_year}-{$payrollItem->payrollRun?->period_month}.pdf",
+            ['Content-Type' => 'application/pdf']
+        );
     }
 }

--- a/backend/app/Http/Resources/PayrollItemResource.php
+++ b/backend/app/Http/Resources/PayrollItemResource.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PayrollItemResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        $employment = $this->whenLoaded('employment');
+
+        return [
+            'id'                 => $this->id,
+            'payroll_run_id'     => $this->payroll_run_id,
+            'employment_id'      => $this->employment_id,
+
+            // Employee snapshot (when employment is loaded)
+            'employee'           => $this->when($this->relationLoaded('employment') && $employment, function () use ($employment) {
+                return [
+                    'id'              => $employment->id,
+                    'employee_number' => $employment->employee_number,
+                    'position'        => $employment->position,
+                    'department'      => $employment->department,
+                    'user'            => $this->when(
+                        $employment->relationLoaded('user') && $employment->user,
+                        fn () => [
+                            'id'    => $employment->user->id,
+                            'name'  => $employment->user->name,
+                            'email' => $employment->user->email,
+                        ]
+                    ),
+                ];
+            }),
+
+            // Salary components
+            'gross_salary'       => $this->gross_salary,
+            'net_salary'         => $this->net_salary,
+            'allowances'         => $this->allowances ?? [],
+            'deductions'         => $this->deductions ?? [],
+
+            // BPJS Kesehatan
+            'bpjs_kes_employee'  => $this->bpjs_kes_employee,
+            'bpjs_kes_employer'  => $this->bpjs_kes_employer,
+
+            // BPJS TK
+            'bpjs_jht_employee'  => $this->bpjs_jht_employee,
+            'bpjs_jht_employer'  => $this->bpjs_jht_employer,
+            'bpjs_jkk'           => $this->bpjs_jkk,
+            'bpjs_jkm'           => $this->bpjs_jkm,
+            'bpjs_jp_employee'   => $this->bpjs_jp_employee,
+            'bpjs_jp_employer'   => $this->bpjs_jp_employer,
+
+            // PPh 21
+            'pph21_annual_base'  => $this->pph21_annual_base,
+            'pph21_amount'       => $this->pph21_amount,
+            'pph21_breakdown'    => $this->pph21_breakdown ?? [],
+
+            // Attendance
+            'working_days'       => $this->working_days,
+            'present_days'       => $this->present_days,
+            'absent_days'        => $this->absent_days,
+            'leave_days'         => $this->leave_days,
+
+            // Slip
+            'slip_url'           => $this->slip_url,
+
+            'created_at'         => $this->created_at?->toIso8601String(),
+            'updated_at'         => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/backend/app/Http/Resources/PayrollRunResource.php
+++ b/backend/app/Http/Resources/PayrollRunResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PayrollRunResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'              => $this->id,
+            'entity_id'       => $this->entity_id,
+            'period_month'    => $this->period_month,
+            'period_year'     => $this->period_year,
+            'status'          => $this->status,
+            'total_gross'     => $this->total_gross,
+            'total_net'       => $this->total_net,
+            'total_employees' => $this->total_employees,
+            'processed_by'    => $this->processed_by,
+            'processed_at'    => $this->processed_at?->toIso8601String(),
+            'locked_by'       => $this->locked_by,
+            'locked_at'       => $this->locked_at?->toIso8601String(),
+            'created_at'      => $this->created_at?->toIso8601String(),
+            'updated_at'      => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/backend/app/Jobs/GeneratePayslipJob.php
+++ b/backend/app/Jobs/GeneratePayslipJob.php
@@ -33,6 +33,11 @@ class GeneratePayslipJob implements ShouldQueue
             return;
         }
 
+        // Skip if slip was already generated (prevents double dispatch on retry)
+        if ($item->slip_url) {
+            return;
+        }
+
         $employment = $item->employment;
         $user       = $employment?->user;
         $entity     = $employment?->entity;
@@ -59,12 +64,13 @@ class GeneratePayslipJob implements ShouldQueue
 
         $pdf->setPaper('A4', 'portrait');
 
-        // 4. Store PDF on public disk
+        // 4. Store PDF on the local (private) disk — not publicly accessible via URL.
+        //    Slips are served through the authenticated /api/payroll/items/{id}/slip-download
+        //    endpoint rather than being exposed directly via public storage.
         $relativePath = "slips/{$run->id}/{$employment->id}.pdf";
-        Storage::disk('public')->put($relativePath, $pdf->output());
+        Storage::disk('local')->put($relativePath, $pdf->output());
 
-        // 5. Persist the slip_url on the PayrollItem
-        $slipUrl = Storage::disk('public')->url($relativePath);
-        $item->update(['slip_url' => $slipUrl]);
+        // 5. Persist the relative path on the PayrollItem (not a public URL)
+        $item->update(['slip_url' => $relativePath]);
     }
 }

--- a/backend/app/Jobs/GeneratePayslipJob.php
+++ b/backend/app/Jobs/GeneratePayslipJob.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\PayrollItem;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+class GeneratePayslipJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public readonly string $payrollItemId
+    ) {
+        $this->onQueue('default');
+    }
+
+    public function handle(): void
+    {
+        // 1. Load PayrollItem with nested employment → user and employment → entity
+        $item = PayrollItem::with([
+            'employment.user',
+            'employment.entity',
+            'payrollRun',
+        ])->find($this->payrollItemId);
+
+        if (! $item) {
+            Log::warning("GeneratePayslipJob: PayrollItem [{$this->payrollItemId}] not found.");
+            return;
+        }
+
+        $employment = $item->employment;
+        $user       = $employment?->user;
+        $entity     = $employment?->entity;
+        $run        = $item->payrollRun;
+
+        if (! $employment || ! $user || ! $entity || ! $run) {
+            Log::warning("GeneratePayslipJob: Missing relations for PayrollItem [{$this->payrollItemId}].");
+            return;
+        }
+
+        // 2. Build period label (e.g. "April 2025")
+        $periodLabel = \Carbon\Carbon::createFromDate($run->period_year, $run->period_month, 1)
+            ->locale('id')
+            ->isoFormat('MMMM YYYY');
+
+        // 3. Generate PDF from Blade view
+        $pdf = Pdf::loadView('payroll.slip', [
+            'item'        => $item,
+            'employment'  => $employment,
+            'user'        => $user,
+            'entity'      => $entity,
+            'periodLabel' => $periodLabel,
+        ]);
+
+        $pdf->setPaper('A4', 'portrait');
+
+        // 4. Store PDF on public disk
+        $relativePath = "slips/{$run->id}/{$employment->id}.pdf";
+        Storage::disk('public')->put($relativePath, $pdf->output());
+
+        // 5. Persist the slip_url on the PayrollItem
+        $slipUrl = Storage::disk('public')->url($relativePath);
+        $item->update(['slip_url' => $slipUrl]);
+    }
+}

--- a/backend/app/Jobs/ProcessPayrollJob.php
+++ b/backend/app/Jobs/ProcessPayrollJob.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Employment;
+use App\Models\PayrollItem;
+use App\Models\PayrollRun;
+use App\Services\PayrollCalculatorService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+class ProcessPayrollJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public readonly string $payrollRunId,
+        public readonly ?string $processedBy = null
+    ) {
+        $this->onQueue('default');
+    }
+
+    public function handle(PayrollCalculatorService $service): void
+    {
+        // 1. Load the PayrollRun — abort if not DRAFT
+        $run = PayrollRun::find($this->payrollRunId);
+
+        if (! $run) {
+            Log::warning("ProcessPayrollJob: PayrollRun [{$this->payrollRunId}] not found.");
+            return;
+        }
+
+        if ($run->status !== 'DRAFT') {
+            Log::info("ProcessPayrollJob: PayrollRun [{$this->payrollRunId}] is not DRAFT (status={$run->status}). Skipping.");
+            return;
+        }
+
+        // 2. Load all ACTIVE employments for the entity
+        $employments = Employment::where('entity_id', $run->entity_id)
+            ->where('status', 'ACTIVE')
+            ->with(['user', 'entity'])
+            ->get();
+
+        $totalGross      = 0;
+        $totalNet        = 0;
+        $totalEmployees  = 0;
+        $createdItemIds  = [];
+
+        // 3. For each employment: calculate and upsert a PayrollItem
+        foreach ($employments as $employment) {
+            try {
+                $data = $service->calculate($employment, $run->period_month, $run->period_year);
+
+                $item = PayrollItem::updateOrCreate(
+                    [
+                        'payroll_run_id' => $run->id,
+                        'employment_id'  => $employment->id,
+                    ],
+                    array_merge($data, [
+                        'payroll_run_id' => $run->id,
+                        'employment_id'  => $employment->id,
+                    ])
+                );
+
+                $totalGross     += $item->gross_salary;
+                $totalNet       += $item->net_salary;
+                $totalEmployees++;
+                $createdItemIds[] = $item->id;
+            } catch (\Throwable $e) {
+                Log::error("ProcessPayrollJob: Failed to calculate for employment [{$employment->id}]: {$e->getMessage()}");
+            }
+        }
+
+        // 4. Update PayrollRun totals and status
+        $run->update([
+            'status'          => 'PROCESSED',
+            'total_employees' => $totalEmployees,
+            'total_gross'     => $totalGross,
+            'total_net'       => $totalNet,
+            'processed_by'    => $this->processedBy,
+            'processed_at'    => now(),
+        ]);
+
+        // 5. Dispatch GeneratePayslipJob for each item
+        foreach ($createdItemIds as $itemId) {
+            GeneratePayslipJob::dispatch($itemId);
+        }
+    }
+}

--- a/backend/app/Jobs/ProcessPayrollJob.php
+++ b/backend/app/Jobs/ProcessPayrollJob.php
@@ -99,10 +99,13 @@ class ProcessPayrollJob implements ShouldQueue
                 'processed_at'    => now(),
             ]);
 
-            // 6. Dispatch GeneratePayslipJob for each item
-            foreach ($createdItemIds as $itemId) {
-                GeneratePayslipJob::dispatch($itemId);
-            }
+            // 6. Dispatch GeneratePayslipJob AFTER the transaction commits so the
+            //    job always reads fully-committed PayrollItem rows from the database.
+            DB::afterCommit(function () use ($createdItemIds) {
+                foreach ($createdItemIds as $itemId) {
+                    GeneratePayslipJob::dispatch($itemId);
+                }
+            });
         });
     }
 }

--- a/backend/app/Jobs/ProcessPayrollJob.php
+++ b/backend/app/Jobs/ProcessPayrollJob.php
@@ -8,6 +8,7 @@ use App\Models\PayrollRun;
 use App\Services\PayrollCalculatorService;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 class ProcessPayrollJob implements ShouldQueue
@@ -23,68 +24,85 @@ class ProcessPayrollJob implements ShouldQueue
 
     public function handle(PayrollCalculatorService $service): void
     {
-        // 1. Load the PayrollRun — abort if not DRAFT
-        $run = PayrollRun::find($this->payrollRunId);
+        // 1. Load + lock the PayrollRun inside a transaction to prevent double-processing
+        DB::transaction(function () use ($service) {
+            $run = PayrollRun::lockForUpdate()->find($this->payrollRunId);
 
-        if (! $run) {
-            Log::warning("ProcessPayrollJob: PayrollRun [{$this->payrollRunId}] not found.");
-            return;
-        }
-
-        if ($run->status !== 'DRAFT') {
-            Log::info("ProcessPayrollJob: PayrollRun [{$this->payrollRunId}] is not DRAFT (status={$run->status}). Skipping.");
-            return;
-        }
-
-        // 2. Load all ACTIVE employments for the entity
-        $employments = Employment::where('entity_id', $run->entity_id)
-            ->where('status', 'ACTIVE')
-            ->with(['user', 'entity'])
-            ->get();
-
-        $totalGross      = 0;
-        $totalNet        = 0;
-        $totalEmployees  = 0;
-        $createdItemIds  = [];
-
-        // 3. For each employment: calculate and upsert a PayrollItem
-        foreach ($employments as $employment) {
-            try {
-                $data = $service->calculate($employment, $run->period_month, $run->period_year);
-
-                $item = PayrollItem::updateOrCreate(
-                    [
-                        'payroll_run_id' => $run->id,
-                        'employment_id'  => $employment->id,
-                    ],
-                    array_merge($data, [
-                        'payroll_run_id' => $run->id,
-                        'employment_id'  => $employment->id,
-                    ])
-                );
-
-                $totalGross     += $item->gross_salary;
-                $totalNet       += $item->net_salary;
-                $totalEmployees++;
-                $createdItemIds[] = $item->id;
-            } catch (\Throwable $e) {
-                Log::error("ProcessPayrollJob: Failed to calculate for employment [{$employment->id}]: {$e->getMessage()}");
+            if (! $run) {
+                Log::warning("ProcessPayrollJob: PayrollRun [{$this->payrollRunId}] not found.");
+                return;
             }
-        }
 
-        // 4. Update PayrollRun totals and status
-        $run->update([
-            'status'          => 'PROCESSED',
-            'total_employees' => $totalEmployees,
-            'total_gross'     => $totalGross,
-            'total_net'       => $totalNet,
-            'processed_by'    => $this->processedBy,
-            'processed_at'    => now(),
-        ]);
+            if ($run->status !== 'DRAFT') {
+                Log::info("ProcessPayrollJob: PayrollRun [{$this->payrollRunId}] is not DRAFT (status={$run->status}). Skipping.");
+                return;
+            }
 
-        // 5. Dispatch GeneratePayslipJob for each item
-        foreach ($createdItemIds as $itemId) {
-            GeneratePayslipJob::dispatch($itemId);
-        }
+            // 2. Load all ACTIVE employments and pre-fetch attendances for the period
+            //    in a single query to avoid N+1 inside the calculator
+            $employments = Employment::where('entity_id', $run->entity_id)
+                ->where('status', 'ACTIVE')
+                ->with(['user', 'entity'])
+                ->get();
+
+            $service->prefetchAttendances(
+                $employments->pluck('id')->all(),
+                $run->period_month,
+                $run->period_year
+            );
+
+            $totalGross     = 0;
+            $totalNet       = 0;
+            $totalEmployees = 0;
+            $createdItemIds = [];
+            $failures       = 0;
+
+            // 3. For each employment: calculate and upsert a PayrollItem
+            foreach ($employments as $employment) {
+                try {
+                    $data = $service->calculate($employment, $run->period_month, $run->period_year);
+
+                    $item = PayrollItem::updateOrCreate(
+                        [
+                            'payroll_run_id' => $run->id,
+                            'employment_id'  => $employment->id,
+                        ],
+                        array_merge($data, [
+                            'payroll_run_id' => $run->id,
+                            'employment_id'  => $employment->id,
+                        ])
+                    );
+
+                    $totalGross     += $item->gross_salary;
+                    $totalNet       += $item->net_salary;
+                    $totalEmployees++;
+                    $createdItemIds[] = $item->id;
+                } catch (\Throwable $e) {
+                    $failures++;
+                    Log::error("ProcessPayrollJob: Failed to calculate for employment [{$employment->id}]: {$e->getMessage()}");
+                }
+            }
+
+            // 4. Only mark PROCESSED when all employments succeeded
+            if ($failures > 0) {
+                Log::error("ProcessPayrollJob: PayrollRun [{$run->id}] completed with {$failures} failure(s). Staying in DRAFT.");
+                return;
+            }
+
+            // 5. Update PayrollRun totals and status
+            $run->update([
+                'status'          => 'PROCESSED',
+                'total_employees' => $totalEmployees,
+                'total_gross'     => $totalGross,
+                'total_net'       => $totalNet,
+                'processed_by'    => $this->processedBy,
+                'processed_at'    => now(),
+            ]);
+
+            // 6. Dispatch GeneratePayslipJob for each item
+            foreach ($createdItemIds as $itemId) {
+                GeneratePayslipJob::dispatch($itemId);
+            }
+        });
     }
 }

--- a/backend/app/Services/PayrollCalculatorService.php
+++ b/backend/app/Services/PayrollCalculatorService.php
@@ -5,9 +5,12 @@ namespace App\Services;
 use App\Models\Attendance;
 use App\Models\Employment;
 use Carbon\Carbon;
+use Illuminate\Support\Collection;
 
 class PayrollCalculatorService
 {
+    /** @var array<string, Collection> Keyed by "employmentId:month:year" */
+    private array $attendanceCache = [];
     /**
      * PTKP values per status (annual, in IDR)
      */
@@ -52,10 +55,7 @@ class PayrollCalculatorService
         // ── B. Attendance ────────────────────────────────────────────────────
         $workingDays = $this->countBusinessDays($month, $year);
 
-        $attendances  = Attendance::where('employment_id', $employment->id)
-            ->whereYear('date', $year)
-            ->whereMonth('date', $month)
-            ->get();
+        $attendances = $this->getAttendances($employment->id, $month, $year);
 
         $presentDays = $attendances->whereIn('status', ['PRESENT', 'LATE'])->count();
         $leaveDays   = $attendances->where('status', 'LEAVE')->count();
@@ -91,10 +91,13 @@ class PayrollCalculatorService
         }
 
         // ── E. PPh 21 ────────────────────────────────────────────────────────
+        // Per PMK 168/2023, BPJS JP employee contribution is deducted before
+        // computing PKP (treated as a pre-tax deduction alongside biaya jabatan).
         $annualGross    = $gross * 12;
+        $annualBpjsJp   = $bpjsJpEmployee * 12;
         $biayaJabatan   = min((int) round(0.05 * $annualGross), 6_000_000);
         $ptkp           = self::PTKP[$employment->ptkp_status ?? 'TK0'] ?? 54_000_000;
-        $pkp            = max(0, $annualGross - $biayaJabatan - $ptkp);
+        $pkp            = max(0, $annualGross - $biayaJabatan - $annualBpjsJp - $ptkp);
 
         [$annualTax, $pph21Breakdown] = $this->calculateProgressiveTax($pkp);
 
@@ -137,6 +140,44 @@ class PayrollCalculatorService
             'absent_days'        => $absentDays,
             'leave_days'         => $leaveDays,
         ];
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Cache helpers (N+1 prevention)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Pre-load all attendance rows for a batch of employments in a single query.
+     * Call this before processing a full payroll run to avoid N+1 per employee.
+     *
+     * @param  string[]  $employmentIds
+     */
+    public function prefetchAttendances(array $employmentIds, int $month, int $year): void
+    {
+        $rows = Attendance::whereIn('employment_id', $employmentIds)
+            ->whereYear('date', $year)
+            ->whereMonth('date', $month)
+            ->get()
+            ->groupBy('employment_id');
+
+        foreach ($employmentIds as $id) {
+            $key = "{$id}:{$month}:{$year}";
+            $this->attendanceCache[$key] = $rows->get($id, collect());
+        }
+    }
+
+    private function getAttendances(string $employmentId, int $month, int $year): Collection
+    {
+        $key = "{$employmentId}:{$month}:{$year}";
+
+        if (! isset($this->attendanceCache[$key])) {
+            $this->attendanceCache[$key] = Attendance::where('employment_id', $employmentId)
+                ->whereYear('date', $year)
+                ->whereMonth('date', $month)
+                ->get();
+        }
+
+        return $this->attendanceCache[$key];
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/backend/app/Services/PayrollCalculatorService.php
+++ b/backend/app/Services/PayrollCalculatorService.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Attendance;
+use App\Models\Employment;
+use Carbon\Carbon;
+
+class PayrollCalculatorService
+{
+    /**
+     * PTKP values per status (annual, in IDR)
+     */
+    private const PTKP = [
+        'TK0' => 54_000_000,
+        'TK1' => 58_500_000,
+        'TK2' => 63_000_000,
+        'TK3' => 67_500_000,
+        'K0'  => 58_500_000,
+        'K1'  => 63_000_000,
+        'K2'  => 67_500_000,
+        'K3'  => 72_000_000,
+    ];
+
+    /**
+     * PPh 21 progressive tax brackets (UU HPP 2021 / Pasal 17)
+     * Each entry: [upper_limit, rate]
+     * The last bracket has no upper limit (PHP_INT_MAX is used).
+     */
+    private const PPH21_BRACKETS = [
+        [60_000_000,         0.05],
+        [250_000_000,        0.15],
+        [500_000_000,        0.25],
+        [5_000_000_000,      0.30],
+        [PHP_INT_MAX,        0.35],
+    ];
+
+    /**
+     * Calculate all payroll fields for one employment in a given month/year.
+     *
+     * @return array<string, mixed>  All fields needed to create/update a PayrollItem.
+     */
+    public function calculate(Employment $employment, int $month, int $year): array
+    {
+        // ── A. Gross salary ──────────────────────────────────────────────────
+        $allowances = $this->extractComponents($employment->salary_structure ?? [], 'ALLOWANCE');
+        $deductions  = $this->extractComponents($employment->salary_structure ?? [], 'DEDUCTION');
+
+        $allowancesTotal = array_sum(array_column($allowances, 'amount'));
+        $gross           = (int) $employment->salary_basic + $allowancesTotal;
+
+        // ── B. Attendance ────────────────────────────────────────────────────
+        $workingDays = $this->countBusinessDays($month, $year);
+
+        $attendances  = Attendance::where('employment_id', $employment->id)
+            ->whereYear('date', $year)
+            ->whereMonth('date', $month)
+            ->get();
+
+        $presentDays = $attendances->whereIn('status', ['PRESENT', 'LATE'])->count();
+        $leaveDays   = $attendances->where('status', 'LEAVE')->count();
+        $absentDays  = max(0, $workingDays - $presentDays - $leaveDays);
+
+        // ── C. BPJS Kesehatan ────────────────────────────────────────────────
+        $bpjsKesEmployee = 0;
+        $bpjsKesEmployer = 0;
+
+        if ($employment->bpjs_kesehatan === true) {
+            $kesBase         = min($gross, 12_000_000);
+            $bpjsKesEmployee = (int) round(0.01 * $kesBase);
+            $bpjsKesEmployer = (int) round(0.04 * $kesBase);
+        }
+
+        // ── D. BPJS Ketenagakerjaan ──────────────────────────────────────────
+        $bpjsJhtEmployee = 0;
+        $bpjsJhtEmployer = 0;
+        $bpjsJkk         = 0;
+        $bpjsJkm         = 0;
+        $bpjsJpEmployee  = 0;
+        $bpjsJpEmployer  = 0;
+
+        if ($employment->bpjs_tk === true) {
+            $bpjsJhtEmployee = (int) round(0.02   * $gross);
+            $bpjsJhtEmployer = (int) round(0.037  * $gross);
+            $bpjsJkk         = (int) round(0.0024 * $gross);
+            $bpjsJkm         = (int) round(0.003  * $gross);
+
+            $jpBase         = min($gross, 9_077_600);
+            $bpjsJpEmployee = (int) round(0.01 * $jpBase);
+            $bpjsJpEmployer = (int) round(0.02 * $jpBase);
+        }
+
+        // ── E. PPh 21 ────────────────────────────────────────────────────────
+        $annualGross    = $gross * 12;
+        $biayaJabatan   = min((int) round(0.05 * $annualGross), 6_000_000);
+        $ptkp           = self::PTKP[$employment->ptkp_status ?? 'TK0'] ?? 54_000_000;
+        $pkp            = max(0, $annualGross - $biayaJabatan - $ptkp);
+
+        [$annualTax, $pph21Breakdown] = $this->calculateProgressiveTax($pkp);
+
+        $pph21AnnualBase = $pkp;
+        $pph21Amount     = (int) round($annualTax / 12);
+
+        // ── F. Net salary ────────────────────────────────────────────────────
+        $employeeDeductions     = $bpjsKesEmployee + $bpjsJhtEmployee + $bpjsJpEmployee + $pph21Amount;
+        $customDeductionsTotal  = array_sum(array_column($deductions, 'amount'));
+        $netSalary              = max(0, $gross - $employeeDeductions - $customDeductionsTotal);
+
+        return [
+            'gross_salary'       => $gross,
+            'allowances'         => $allowances,
+            'deductions'         => $deductions,
+
+            // BPJS Kesehatan
+            'bpjs_kes_employee'  => $bpjsKesEmployee,
+            'bpjs_kes_employer'  => $bpjsKesEmployer,
+
+            // BPJS TK
+            'bpjs_jht_employee'  => $bpjsJhtEmployee,
+            'bpjs_jht_employer'  => $bpjsJhtEmployer,
+            'bpjs_jkk'           => $bpjsJkk,
+            'bpjs_jkm'           => $bpjsJkm,
+            'bpjs_jp_employee'   => $bpjsJpEmployee,
+            'bpjs_jp_employer'   => $bpjsJpEmployer,
+
+            // PPh 21
+            'pph21_annual_base'  => $pph21AnnualBase,
+            'pph21_amount'       => $pph21Amount,
+            'pph21_breakdown'    => $pph21Breakdown,
+
+            // Net
+            'net_salary'         => $netSalary,
+
+            // Attendance
+            'working_days'       => $workingDays,
+            'present_days'       => $presentDays,
+            'absent_days'        => $absentDays,
+            'leave_days'         => $leaveDays,
+        ];
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Private helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Filter salary_structure components by type and return only name + amount.
+     *
+     * @param  array<int, array{name: string, amount: int|float, type: string}>  $structure
+     * @param  string  $type  'ALLOWANCE' or 'DEDUCTION'
+     * @return array<int, array{name: string, amount: int}>
+     */
+    private function extractComponents(array $structure, string $type): array
+    {
+        $result = [];
+
+        foreach ($structure as $item) {
+            if (isset($item['type']) && strtoupper($item['type']) === $type) {
+                $result[] = [
+                    'name'   => $item['name'] ?? '',
+                    'amount' => (int) ($item['amount'] ?? 0),
+                ];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Count business days (Mon–Fri) in the given month/year.
+     */
+    private function countBusinessDays(int $month, int $year): int
+    {
+        $start   = Carbon::createFromDate($year, $month, 1)->startOfMonth();
+        $end     = $start->copy()->endOfMonth();
+        $count   = 0;
+        $current = $start->copy();
+
+        while ($current->lte($end)) {
+            if ($current->isWeekday()) {
+                $count++;
+            }
+            $current->addDay();
+        }
+
+        return $count;
+    }
+
+    /**
+     * Apply UU HPP 2021 Pasal 17 progressive rates to PKP (annual).
+     *
+     * @return array{0: int, 1: array<int, array{bracket: string, taxable: int, rate: float, tax: int}>}
+     */
+    private function calculateProgressiveTax(int $pkp): array
+    {
+        $annualTax = 0;
+        $breakdown = [];
+        $previous  = 0;
+
+        foreach (self::PPH21_BRACKETS as [$ceiling, $rate]) {
+            if ($pkp <= $previous) {
+                break;
+            }
+
+            $taxable   = min($pkp, $ceiling) - $previous;
+            $tax       = (int) round($taxable * $rate);
+            $annualTax += $tax;
+
+            if ($ceiling === PHP_INT_MAX) {
+                $bracketLabel = 'Di atas Rp 5.000.000.000';
+            } elseif ($previous === 0) {
+                $bracketLabel = 'Sampai Rp ' . number_format($ceiling, 0, ',', '.');
+            } else {
+                $bracketLabel = 'Rp ' . number_format($previous + 1, 0, ',', '.') . ' – Rp ' . number_format($ceiling, 0, ',', '.');
+            }
+
+            $breakdown[] = [
+                'bracket' => $bracketLabel,
+                'taxable' => $taxable,
+                'rate'    => $rate,
+                'tax'     => $tax,
+            ];
+
+            $previous = $ceiling;
+        }
+
+        return [$annualTax, $breakdown];
+    }
+}

--- a/backend/resources/views/payroll/slip.blade.php
+++ b/backend/resources/views/payroll/slip.blade.php
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+    <meta charset="UTF-8">
+    <title>Slip Gaji - {{ $user->name ?? '' }} - {{ $periodLabel }}</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: Arial, sans-serif; font-size: 12px; color: #333; padding: 20px; }
+        .header { text-align: center; margin-bottom: 20px; border-bottom: 2px solid #333; padding-bottom: 12px; }
+        .header h2 { font-size: 16px; text-transform: uppercase; letter-spacing: 1px; }
+        .header p { font-size: 13px; margin-top: 4px; font-weight: bold; color: #555; }
+        .employee-info { margin-bottom: 16px; }
+        .employee-info table { width: 100%; }
+        .employee-info td { padding: 3px 6px; vertical-align: top; }
+        .employee-info td:first-child { width: 140px; color: #666; }
+        .section { margin-bottom: 16px; }
+        .section-title { font-weight: bold; font-size: 11px; text-transform: uppercase;
+                         letter-spacing: 0.5px; color: #555; background: #f5f5f5;
+                         padding: 4px 8px; border-left: 3px solid #333; margin-bottom: 4px; }
+        .section table { width: 100%; border-collapse: collapse; }
+        .section td { padding: 4px 8px; border-bottom: 1px solid #eee; }
+        .section td:last-child { text-align: right; }
+        .section tfoot td { font-weight: bold; border-top: 1px solid #999; border-bottom: none;
+                            background: #f9f9f9; }
+        .net-salary { background: #333; color: #fff; padding: 10px 16px;
+                      display: flex; justify-content: space-between; align-items: center;
+                      margin-top: 8px; }
+        .net-salary .label { font-size: 13px; font-weight: bold; text-transform: uppercase; }
+        .net-salary .amount { font-size: 16px; font-weight: bold; }
+        .attendance-row td { color: #555; }
+        .footer { margin-top: 30px; text-align: right; font-size: 11px; color: #999; }
+    </style>
+</head>
+<body>
+
+    {{-- ── Header ─────────────────────────────────────────────────────────── --}}
+    <div class="header">
+        <h2>{{ $entity->name }}</h2>
+        <p>SLIP GAJI &mdash; {{ strtoupper($periodLabel) }}</p>
+    </div>
+
+    {{-- ── Employee Info ────────────────────────────────────────────────────── --}}
+    <div class="employee-info">
+        <table>
+            <tr>
+                <td>Nama</td>
+                <td>: <strong>{{ $user->name ?? '-' }}</strong></td>
+                <td>No. Karyawan</td>
+                <td>: {{ $employment->employee_number ?? '-' }}</td>
+            </tr>
+            <tr>
+                <td>Jabatan</td>
+                <td>: {{ $employment->position ?? '-' }}</td>
+                <td>Departemen</td>
+                <td>: {{ $employment->department ?? '-' }}</td>
+            </tr>
+            <tr>
+                <td>Status PTKP</td>
+                <td>: {{ $employment->ptkp_status ?? '-' }}</td>
+                <td>Jenis Karyawan</td>
+                <td>: {{ $employment->employment_type ?? '-' }}</td>
+            </tr>
+        </table>
+    </div>
+
+    {{-- ── Earnings ─────────────────────────────────────────────────────────── --}}
+    <div class="section">
+        <div class="section-title">Pendapatan</div>
+        <table>
+            <tbody>
+                <tr>
+                    <td>Gaji Pokok</td>
+                    <td>Rp {{ number_format($employment->salary_basic, 0, ',', '.') }}</td>
+                </tr>
+                @if (!empty($item->allowances))
+                    @foreach ($item->allowances as $allowance)
+                    <tr>
+                        <td>{{ $allowance['name'] }}</td>
+                        <td>Rp {{ number_format($allowance['amount'], 0, ',', '.') }}</td>
+                    </tr>
+                    @endforeach
+                @endif
+            </tbody>
+            <tfoot>
+                <tr>
+                    <td>Total Pendapatan Kotor</td>
+                    <td>Rp {{ number_format($item->gross_salary, 0, ',', '.') }}</td>
+                </tr>
+            </tfoot>
+        </table>
+    </div>
+
+    {{-- ── Deductions ───────────────────────────────────────────────────────── --}}
+    <div class="section">
+        <div class="section-title">Potongan</div>
+        <table>
+            <tbody>
+                @if ($item->bpjs_kes_employee > 0)
+                <tr>
+                    <td>BPJS Kesehatan (1%)</td>
+                    <td>Rp {{ number_format($item->bpjs_kes_employee, 0, ',', '.') }}</td>
+                </tr>
+                @endif
+                @if ($item->bpjs_jht_employee > 0)
+                <tr>
+                    <td>BPJS JHT Karyawan (2%)</td>
+                    <td>Rp {{ number_format($item->bpjs_jht_employee, 0, ',', '.') }}</td>
+                </tr>
+                @endif
+                @if ($item->bpjs_jp_employee > 0)
+                <tr>
+                    <td>BPJS JP Karyawan (1%)</td>
+                    <td>Rp {{ number_format($item->bpjs_jp_employee, 0, ',', '.') }}</td>
+                </tr>
+                @endif
+                @if ($item->pph21_amount > 0)
+                <tr>
+                    <td>PPh 21</td>
+                    <td>Rp {{ number_format($item->pph21_amount, 0, ',', '.') }}</td>
+                </tr>
+                @endif
+                @if (!empty($item->deductions))
+                    @foreach ($item->deductions as $deduction)
+                    <tr>
+                        <td>{{ $deduction['name'] }}</td>
+                        <td>Rp {{ number_format($deduction['amount'], 0, ',', '.') }}</td>
+                    </tr>
+                    @endforeach
+                @endif
+            </tbody>
+            <tfoot>
+                @php
+                    $totalDeductions = $item->bpjs_kes_employee
+                        + $item->bpjs_jht_employee
+                        + $item->bpjs_jp_employee
+                        + $item->pph21_amount
+                        + array_sum(array_column($item->deductions ?? [], 'amount'));
+                @endphp
+                <tr>
+                    <td>Total Potongan</td>
+                    <td>Rp {{ number_format($totalDeductions, 0, ',', '.') }}</td>
+                </tr>
+            </tfoot>
+        </table>
+    </div>
+
+    {{-- ── Attendance Summary ───────────────────────────────────────────────── --}}
+    <div class="section">
+        <div class="section-title">Rekap Kehadiran</div>
+        <table>
+            <tbody class="attendance-row">
+                <tr>
+                    <td>Hari Kerja</td>
+                    <td>{{ $item->working_days }} hari</td>
+                </tr>
+                <tr>
+                    <td>Hadir</td>
+                    <td>{{ $item->present_days }} hari</td>
+                </tr>
+                <tr>
+                    <td>Cuti</td>
+                    <td>{{ $item->leave_days }} hari</td>
+                </tr>
+                <tr>
+                    <td>Tidak Hadir</td>
+                    <td>{{ $item->absent_days }} hari</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    {{-- ── Employer BPJS Contributions (informational) ─────────────────────── --}}
+    @if ($item->bpjs_kes_employer > 0 || $item->bpjs_jht_employer > 0 || $item->bpjs_jp_employer > 0)
+    <div class="section">
+        <div class="section-title">Iuran BPJS Ditanggung Perusahaan</div>
+        <table>
+            <tbody>
+                @if ($item->bpjs_kes_employer > 0)
+                <tr>
+                    <td>BPJS Kesehatan Perusahaan (4%)</td>
+                    <td>Rp {{ number_format($item->bpjs_kes_employer, 0, ',', '.') }}</td>
+                </tr>
+                @endif
+                @if ($item->bpjs_jht_employer > 0)
+                <tr>
+                    <td>BPJS JHT Perusahaan (3,7%)</td>
+                    <td>Rp {{ number_format($item->bpjs_jht_employer, 0, ',', '.') }}</td>
+                </tr>
+                @endif
+                @if ($item->bpjs_jkk > 0)
+                <tr>
+                    <td>BPJS JKK (0,24%)</td>
+                    <td>Rp {{ number_format($item->bpjs_jkk, 0, ',', '.') }}</td>
+                </tr>
+                @endif
+                @if ($item->bpjs_jkm > 0)
+                <tr>
+                    <td>BPJS JKM (0,3%)</td>
+                    <td>Rp {{ number_format($item->bpjs_jkm, 0, ',', '.') }}</td>
+                </tr>
+                @endif
+                @if ($item->bpjs_jp_employer > 0)
+                <tr>
+                    <td>BPJS JP Perusahaan (2%)</td>
+                    <td>Rp {{ number_format($item->bpjs_jp_employer, 0, ',', '.') }}</td>
+                </tr>
+                @endif
+            </tbody>
+        </table>
+    </div>
+    @endif
+
+    {{-- ── Net Salary ───────────────────────────────────────────────────────── --}}
+    <div class="net-salary">
+        <span class="label">Gaji Bersih (Take Home Pay)</span>
+        <span class="amount">Rp {{ number_format($item->net_salary, 0, ',', '.') }}</span>
+    </div>
+
+    <div class="footer">
+        Dokumen ini digenerate secara otomatis oleh sistem HRIS Tridaya Sejahtera Group.
+    </div>
+
+</body>
+</html>

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -160,6 +160,10 @@ Route::middleware(['auth:sanctum', 'entity.scope'])
         // can only retrieve their own slip; admins get any slip
         Route::get('/items/{item}/slip', [PayrollController::class, 'slip'])
             ->middleware('permission:payroll.view_own_slip');
+
+        // Streams PDF from local (private) storage — same ownership rules as above
+        Route::get('/items/{item}/slip-download', [PayrollController::class, 'downloadSlip'])
+            ->middleware('permission:payroll.view_own_slip');
     });
 
 // ── LOCATIONS (QR & Geofence config) ─────────────────────────────────────


### PR DESCRIPTION
## Summary
- `PayrollCalculatorService` — PPh 21 progressive tax (UU HPP 2021 Pasal 17), BPJS Kesehatan + Ketenagakerjaan (JHT/JKK/JKM/JP), gross/net calculation
- `ProcessPayrollJob` — async queue job iterating all ACTIVE employments for the entity, upserting `PayrollItem` records, updating run totals
- `GeneratePayslipJob` — renders PDF via DomPDF from Blade template, stores to `public/slips/{run_id}/{employment_id}.pdf`
- `PayrollController` — full implementation: index (paginated), store (duplicate check), show, process (dispatch job), lock (PROCESSED→PAID), items (department filter), slip (ownership check)
- Resources: `PayrollRunResource`, `PayrollItemResource`

## Test plan
- [ ] POST /api/payroll/runs → creates DRAFT run
- [ ] POST /api/payroll/runs/{id}/process → dispatches job, returns status=processing
- [ ] Queue worker processes job → run status changes to PROCESSED
- [ ] GET /api/payroll/runs/{id}/items → returns calculated items with BPJS/PPh21 breakdown
- [ ] POST /api/payroll/runs/{id}/lock → status changes to PAID
- [ ] GET /api/payroll/items/{id}/slip → returns slip data (employee can only see own)

🤖 Generated with [Claude Code](https://claude.com/claude-code)