### PR TITLE
feat: Export Laporan Payroll (CSV/Excel)

### DIFF
--- a/backend/app/Http/Controllers/PayrollController.php
+++ b/backend/app/Http/Controllers/PayrollController.php
@@ -11,6 +11,7 @@ use App\Models\PayrollRun;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -272,6 +273,107 @@ class PayrollController extends Controller
         }
 
         return $this->success(new PayrollItemResource($payrollItem));
+    }
+
+    /**
+     * Export payroll run to CSV (Excel-compatible) for a PROCESSED or PAID run.
+     */
+    public function export(Request $request, string $run): StreamedResponse|JsonResponse
+    {
+        $entityId = $request->attributes->get('active_entity_id');
+
+        $runQuery = PayrollRun::with(['items.employment.user', 'entity'])->where('id', $run);
+        if ($entityId) {
+            $runQuery->where('entity_id', $entityId);
+        }
+        $payrollRun = $runQuery->first();
+
+        if (! $payrollRun) {
+            return $this->error('Payroll run tidak ditemukan.', 404);
+        }
+
+        if (! in_array($payrollRun->status, ['PROCESSED', 'PAID'])) {
+            return $this->error('Hanya run berstatus PROCESSED atau PAID yang bisa diekspor.', 422);
+        }
+
+        $filename = 'payroll-' . Str::slug($payrollRun->entity->name ?? 'export')
+                  . '-' . $payrollRun->period_month . '-' . $payrollRun->period_year . '.csv';
+
+        $headers = [
+            'Content-Type'        => 'text/csv; charset=UTF-8',
+            'Content-Disposition' => "attachment; filename=\"{$filename}\"",
+        ];
+
+        return response()->stream(function () use ($payrollRun) {
+            $handle = fopen('php://output', 'w');
+            fputs($handle, "\xEF\xBB\xBF"); // UTF-8 BOM so Excel opens correctly
+            fputcsv($handle, [
+                'No', 'NIK', 'Nama', 'Jabatan', 'Departemen',
+                'Gaji Pokok', 'Tunjangan', 'Gross',
+                'BPJS Kes', 'BPJS JHT', 'BPJS JP', 'Total BPJS',
+                'PPh 21', 'Total Potongan', 'Net Salary',
+            ]);
+
+            $totalGajiPokok   = 0;
+            $totalTunjangan   = 0;
+            $totalGross       = 0;
+            $totalBpjsKes     = 0;
+            $totalBpjsJht     = 0;
+            $totalBpjsJp      = 0;
+            $totalBpjs        = 0;
+            $totalPph21       = 0;
+            $totalPotongan    = 0;
+            $totalNet         = 0;
+
+            foreach ($payrollRun->items as $i => $item) {
+                $bpjsKes    = $item->bpjs_kes_employee ?? 0;
+                $bpjsJht    = $item->bpjs_jht_employee ?? 0;
+                $bpjsJp     = $item->bpjs_jp_employee ?? 0;
+                $bpjsTotal  = $bpjsKes + $bpjsJht + $bpjsJp;
+                $pph21      = $item->pph21_amount ?? 0;
+                $totalDeductions = $bpjsTotal + $pph21;
+                $allowances = collect($item->allowances ?? [])->sum('amount');
+
+                fputcsv($handle, [
+                    $i + 1,
+                    $item->employment->nik ?? '',
+                    $item->employment->user->name ?? '',
+                    $item->employment->position ?? '',
+                    $item->employment->department ?? '',
+                    $item->salary_basic ?? 0,
+                    $allowances,
+                    $item->gross_salary ?? 0,
+                    $bpjsKes,
+                    $bpjsJht,
+                    $bpjsJp,
+                    $bpjsTotal,
+                    $pph21,
+                    $totalDeductions,
+                    $item->net_salary ?? 0,
+                ]);
+
+                $totalGajiPokok += $item->salary_basic ?? 0;
+                $totalTunjangan += $allowances;
+                $totalGross     += $item->gross_salary ?? 0;
+                $totalBpjsKes   += $bpjsKes;
+                $totalBpjsJht   += $bpjsJht;
+                $totalBpjsJp    += $bpjsJp;
+                $totalBpjs      += $bpjsTotal;
+                $totalPph21     += $pph21;
+                $totalPotongan  += $totalDeductions;
+                $totalNet       += $item->net_salary ?? 0;
+            }
+
+            // Footer row: totals
+            fputcsv($handle, [
+                'TOTAL', '', '', '', '',
+                $totalGajiPokok, $totalTunjangan, $totalGross,
+                $totalBpjsKes, $totalBpjsJht, $totalBpjsJp, $totalBpjs,
+                $totalPph21, $totalPotongan, $totalNet,
+            ]);
+
+            fclose($handle);
+        }, 200, $headers);
     }
 
     /**

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -153,6 +153,9 @@ Route::middleware(['auth:sanctum', 'entity.scope'])
         Route::post('/runs/{run}/lock', [PayrollController::class, 'lock'])
             ->middleware('permission:payroll.lock');
 
+        Route::get('/runs/{run}/export', [PayrollController::class, 'export'])
+            ->middleware('permission:payroll.view_all');
+
         Route::get('/runs/{run}/items', [PayrollController::class, 'items'])
             ->middleware('permission:payroll.view_all');
 

--- a/frontend/src/app/(dashboard)/payroll/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/payroll/[id]/page.tsx
@@ -71,10 +71,13 @@ export default function PayrollRunDetailPage({ params }: { params: Promise<{ id:
       const response = await apiClient.get(`/payroll/runs/${id}/export`, {
         responseType: 'blob',
       })
+      const disposition = (response.headers['content-disposition'] as string) ?? ''
+      const match = disposition.match(/filename="([^"]+)"/)
+      const filename = match?.[1] ?? `payroll-${id}.csv`
       const url = URL.createObjectURL(new Blob([response.data]))
       const a = document.createElement('a')
       a.href = url
-      a.download = `payroll-${id}.csv`
+      a.download = filename
       document.body.appendChild(a)
       a.click()
       document.body.removeChild(a)

--- a/frontend/src/app/(dashboard)/payroll/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/payroll/[id]/page.tsx
@@ -4,13 +4,14 @@ import { use, useState, useEffect } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
-import { ArrowLeft, Settings, Lock, Loader2 } from 'lucide-react'
+import { ArrowLeft, Settings, Lock, Loader2, Download } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { PayrollStatusBadge } from '@/components/modules/payroll/PayrollStatusBadge'
 import { usePayrollRun, usePayrollItems, useProcessRun, useLockRun } from '@/lib/api/payroll'
 import { formatRupiah, formatMonth } from '@/lib/utils/format'
+import apiClient from '@/lib/api/client'
 import type { PayrollItem } from '@/types'
 
 export default function PayrollRunDetailPage({ params }: { params: Promise<{ id: string }> }) {
@@ -18,6 +19,7 @@ export default function PayrollRunDetailPage({ params }: { params: Promise<{ id:
   const router = useRouter()
   const [polling, setPolling] = useState(false)
   const [showLockConfirm, setShowLockConfirm] = useState(false)
+  const [exporting, setExporting] = useState(false)
 
   const { data: runData, isPending: loadingRun } = usePayrollRun(id, polling ? 3000 : false)
   const run = runData?.data
@@ -60,6 +62,27 @@ export default function PayrollRunDetailPage({ params }: { params: Promise<{ id:
         (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
         'Gagal mengunci payroll run.'
       toast.error(msg)
+    }
+  }
+
+  const handleExport = async () => {
+    setExporting(true)
+    try {
+      const response = await apiClient.get(`/payroll/runs/${id}/export`, {
+        responseType: 'blob',
+      })
+      const url = URL.createObjectURL(new Blob([response.data]))
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `payroll-${id}.csv`
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+    } catch {
+      toast.error('Gagal mengekspor laporan.')
+    } finally {
+      setExporting(false)
     }
   }
 
@@ -117,6 +140,14 @@ export default function PayrollRunDetailPage({ params }: { params: Promise<{ id:
             <Button variant="outline" onClick={() => setShowLockConfirm(true)}>
               <Lock aria-hidden="true" className="h-4 w-4 mr-2" />
               Finalisasi & Kunci
+            </Button>
+          )}
+          {(run.status === 'PROCESSED' || run.status === 'PAID') && (
+            <Button variant="outline" size="sm" onClick={handleExport} disabled={exporting}>
+              {exporting
+                ? <Loader2 aria-hidden="true" className="h-4 w-4 mr-2 animate-spin" />
+                : <Download aria-hidden="true" className="h-4 w-4 mr-2" />}
+              Export Excel
             </Button>
           )}
         </div>


### PR DESCRIPTION
## Summary

- Tambah endpoint `GET /api/payroll/runs/{run}/export` yang menstream CSV ber-BOM UTF-8 (bisa dibuka Excel langsung)
- CSV berisi 15 kolom: No, NIK, Nama, Jabatan, Departemen, Gaji Pokok, Tunjangan, Gross, BPJS Kes, BPJS JHT, BPJS JP, Total BPJS, PPh 21, Total Potongan, Net Salary — plus baris **TOTAL** di footer
- Endpoint diproteksi permission `payroll.view_all` dan scoped per entitas; hanya run berstatus `PROCESSED` atau `PAID` yang bisa diekspor
- Tambah tombol **Export Excel** di `/payroll/[id]` frontend — hanya tampil untuk status `PROCESSED`/`PAID`, dengan loading state saat download berlangsung

## Test plan

- [ ] Login sebagai `entity_admin`, buka payroll run berstatus `PROCESSED` → tombol "Export Excel" muncul
- [ ] Klik tombol → file `.csv` ter-download dengan nama `payroll-{entitas}-{bulan}-{tahun}.csv`
- [ ] Buka file di Excel → kolom terbaca dengan benar, encoding tidak rusak, baris TOTAL ada di akhir
- [ ] Coba export run berstatus `DRAFT` via API → respons 422
- [ ] Pastikan `entity_admin` entitas A tidak bisa export payroll run milik entitas B (respons 404)
- [ ] Buka payroll run berstatus `PAID` → tombol export juga muncul dan berfungsi

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)