### PR TITLE
[BE+FE] Rekap Kehadiran Bulanan — monthly attendance report

### DIFF
--- a/backend/app/Http/Controllers/AttendanceController.php
+++ b/backend/app/Http/Controllers/AttendanceController.php
@@ -378,23 +378,31 @@ class AttendanceController extends Controller
         }
         $employments = $employmentsQuery->get();
 
-        $report = $employments->map(function ($emp) use ($month, $year) {
-            $attendances = Attendance::where('employment_id', $emp->id)
-                ->whereMonth('date', $month)
-                ->whereYear('date', $year)
-                ->get();
+        $employmentIds = $employments->pluck('id');
+        $startOfMonth  = Carbon::createFromDate($year, $month, 1)->startOfMonth();
+        $endOfMonth    = Carbon::createFromDate($year, $month, 1)->endOfMonth();
+
+        // Batch-fetch all attendances and leaves for the month — avoids N+1
+        $attendancesByEmp = Attendance::whereIn('employment_id', $employmentIds)
+            ->whereMonth('date', $month)
+            ->whereYear('date', $year)
+            ->get()
+            ->groupBy('employment_id');
+
+        $leavesByEmp = LeaveRequest::whereIn('employment_id', $employmentIds)
+            ->where('status', 'APPROVED')
+            ->where('start_date', '<=', $endOfMonth)
+            ->where('end_date', '>=', $startOfMonth)
+            ->get()
+            ->groupBy('employment_id');
+
+        $report = $employments->map(function ($emp) use ($attendancesByEmp, $leavesByEmp) {
+            $attendances = $attendancesByEmp[$emp->id] ?? collect();
+            $leaves      = $leavesByEmp[$emp->id] ?? collect();
 
             $present = $attendances->whereIn('status', ['PRESENT', 'LATE'])->count();
             $late    = $attendances->where('status', 'LATE')->count();
             $absent  = $attendances->where('status', 'ABSENT')->count();
-
-            // Hitung cuti yang disetujui di bulan ini
-            $leaveCount = LeaveRequest::where('employment_id', $emp->id)
-                ->where('status', 'APPROVED')
-                ->where(function ($q) use ($month, $year) {
-                    $q->whereMonth('start_date', $month)->whereYear('start_date', $year)
-                      ->orWhereMonth('end_date', $month)->whereYear('end_date', $year);
-                })->count();
 
             return [
                 'employment_id' => $emp->id,
@@ -404,7 +412,7 @@ class AttendanceController extends Controller
                 'present'       => $present,
                 'late'          => $late,
                 'absent'        => $absent,
-                'leave'         => $leaveCount,
+                'leave'         => $leaves->count(),
             ];
         });
 

--- a/backend/app/Http/Controllers/AttendanceController.php
+++ b/backend/app/Http/Controllers/AttendanceController.php
@@ -9,6 +9,7 @@ use App\Http\Resources\AttendanceResource;
 use App\Models\Attendance;
 use App\Models\AuditLog;
 use App\Models\Employment;
+use App\Models\LeaveRequest;
 use App\Models\Location;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Http\JsonResponse;
@@ -336,6 +337,83 @@ class AttendanceController extends Controller
         return $this->success(
             AttendanceResource::collection($attendances)->response()->getData(true)
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // Monthly Report
+    // -------------------------------------------------------------------------
+
+    /**
+     * Return a per-employee attendance summary for a given month/year.
+     * Accessible only to users with the attendance.view_all permission.
+     *
+     * Query params: ?month=5&year=2026
+     */
+    public function monthlyReport(Request $request): JsonResponse
+    {
+        $request->validate([
+            'month' => 'required|integer|min:1|max:12',
+            'year'  => 'required|integer|min:2020|max:2099',
+        ]);
+
+        $month    = (int) $request->month;
+        $year     = (int) $request->year;
+        $entityId = $request->attributes->get('active_entity_id');
+
+        // Hitung total hari kerja di bulan tersebut (Senin-Jumat)
+        $daysInMonth = Carbon::createFromDate($year, $month)->daysInMonth;
+        $workingDays = 0;
+        for ($d = 1; $d <= $daysInMonth; $d++) {
+            $dow = Carbon::createFromDate($year, $month, $d)->dayOfWeek;
+            if ($dow >= 1 && $dow <= 5) {
+                $workingDays++;
+            }
+        }
+
+        // Query semua employments aktif di entitas
+        $employmentsQuery = Employment::with('user')
+            ->where('status', 'active');
+        if ($entityId) {
+            $employmentsQuery->where('entity_id', $entityId);
+        }
+        $employments = $employmentsQuery->get();
+
+        $report = $employments->map(function ($emp) use ($month, $year) {
+            $attendances = Attendance::where('employment_id', $emp->id)
+                ->whereMonth('date', $month)
+                ->whereYear('date', $year)
+                ->get();
+
+            $present = $attendances->whereIn('status', ['PRESENT', 'LATE'])->count();
+            $late    = $attendances->where('status', 'LATE')->count();
+            $absent  = $attendances->where('status', 'ABSENT')->count();
+
+            // Hitung cuti yang disetujui di bulan ini
+            $leaveCount = LeaveRequest::where('employment_id', $emp->id)
+                ->where('status', 'APPROVED')
+                ->where(function ($q) use ($month, $year) {
+                    $q->whereMonth('start_date', $month)->whereYear('start_date', $year)
+                      ->orWhereMonth('end_date', $month)->whereYear('end_date', $year);
+                })->count();
+
+            return [
+                'employment_id' => $emp->id,
+                'name'          => $emp->user->name,
+                'nik'           => $emp->nik,
+                'position'      => $emp->position,
+                'present'       => $present,
+                'late'          => $late,
+                'absent'        => $absent,
+                'leave'         => $leaveCount,
+            ];
+        });
+
+        return $this->success([
+            'month'        => $month,
+            'year'         => $year,
+            'working_days' => $workingDays,
+            'employees'    => $report,
+        ]);
     }
 
     // -------------------------------------------------------------------------

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -104,6 +104,10 @@ Route::middleware(['auth:sanctum'])
         Route::get('/', [AttendanceController::class, 'index'])
             ->middleware('permission:attendance.view_own');
 
+        // Monthly report — must be declared before /{attendance}/correct to avoid route conflict
+        Route::get('/monthly-report', [AttendanceController::class, 'monthlyReport'])
+            ->middleware(['entity.scope', 'permission:attendance.view_all']);
+
         Route::put('/{attendance}/correct', [AttendanceController::class, 'correct'])
             ->middleware(['entity.scope', 'permission:attendance.correct']);
     });

--- a/frontend/src/app/(dashboard)/attendance/report/page.tsx
+++ b/frontend/src/app/(dashboard)/attendance/report/page.tsx
@@ -1,0 +1,289 @@
+'use client'
+
+import { useState } from 'react'
+import { Loader2, Download, BarChart3 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { RoleGate } from '@/components/shared/RoleGate'
+import { useMonthlyReport } from '@/lib/api/attendance'
+
+const MONTHS = [
+  { value: 1, label: 'Januari' },
+  { value: 2, label: 'Februari' },
+  { value: 3, label: 'Maret' },
+  { value: 4, label: 'April' },
+  { value: 5, label: 'Mei' },
+  { value: 6, label: 'Juni' },
+  { value: 7, label: 'Juli' },
+  { value: 8, label: 'Agustus' },
+  { value: 9, label: 'September' },
+  { value: 10, label: 'Oktober' },
+  { value: 11, label: 'November' },
+  { value: 12, label: 'Desember' },
+]
+
+const YEARS = [2023, 2024, 2025, 2026]
+
+interface EmployeeReport {
+  employment_id: string
+  name: string
+  nik: string
+  position: string
+  present: number
+  late: number
+  absent: number
+  leave: number
+}
+
+interface MonthlyReportData {
+  month: number
+  year: number
+  working_days: number
+  employees: EmployeeReport[]
+}
+
+function exportToCsv(data: MonthlyReportData) {
+  const monthLabel = MONTHS.find((m) => m.value === data.month)?.label ?? data.month
+  const headers = ['Nama', 'NIK', 'Posisi', 'Hadir', 'Terlambat', 'Tidak Hadir', 'Cuti', '% Kehadiran', 'Total Hari Kerja']
+  const rows = data.employees.map((emp) => {
+    const attendanceRate = data.working_days > 0
+      ? (((emp.present) / data.working_days) * 100).toFixed(1)
+      : '0.0'
+    return [
+      emp.name,
+      emp.nik ?? '',
+      emp.position,
+      emp.present,
+      emp.late,
+      emp.absent,
+      emp.leave,
+      `${attendanceRate}%`,
+      data.working_days,
+    ]
+  })
+
+  const csvContent = [headers, ...rows]
+    .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(','))
+    .join('\n')
+
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `rekap-kehadiran-${monthLabel}-${data.year}.csv`
+  link.click()
+  URL.revokeObjectURL(url)
+}
+
+function ReportTable({ data }: { data: MonthlyReportData }) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-gray-500">
+          Total hari kerja:{' '}
+          <span className="font-semibold text-gray-900">{data.working_days} hari</span>
+          {' '}— {data.employees.length} karyawan
+        </p>
+        <Button variant="outline" size="sm" onClick={() => exportToCsv(data)}>
+          <Download aria-hidden="true" className="h-4 w-4 mr-2" />
+          Export CSV
+        </Button>
+      </div>
+
+      <div className="overflow-x-auto rounded-md border">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 text-gray-700">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium">Nama</th>
+              <th className="px-4 py-3 text-left font-medium">NIK</th>
+              <th className="px-4 py-3 text-left font-medium">Posisi</th>
+              <th className="px-4 py-3 text-center font-medium">Hadir</th>
+              <th className="px-4 py-3 text-center font-medium">Terlambat</th>
+              <th className="px-4 py-3 text-center font-medium">Tidak Hadir</th>
+              <th className="px-4 py-3 text-center font-medium">Cuti</th>
+              <th className="px-4 py-3 text-center font-medium">% Kehadiran</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {data.employees.map((emp) => {
+              const attendanceRate = data.working_days > 0
+                ? (emp.present / data.working_days) * 100
+                : 0
+              const isLowAttendance = attendanceRate < 80
+
+              return (
+                <tr
+                  key={emp.employment_id}
+                  className={isLowAttendance ? 'bg-red-50' : 'bg-white hover:bg-gray-50'}
+                >
+                  <td className="px-4 py-3 font-medium text-gray-900">{emp.name}</td>
+                  <td className="px-4 py-3 text-gray-600">{emp.nik ?? '-'}</td>
+                  <td className="px-4 py-3 text-gray-600">{emp.position}</td>
+                  <td className="px-4 py-3 text-center">
+                    <span className="inline-flex items-center justify-center w-8 h-6 rounded text-xs font-semibold bg-green-100 text-green-700">
+                      {emp.present}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <span className="inline-flex items-center justify-center w-8 h-6 rounded text-xs font-semibold bg-yellow-100 text-yellow-700">
+                      {emp.late}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <span className="inline-flex items-center justify-center w-8 h-6 rounded text-xs font-semibold bg-red-100 text-red-700">
+                      {emp.absent}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <span className="inline-flex items-center justify-center w-8 h-6 rounded text-xs font-semibold bg-blue-100 text-blue-700">
+                      {emp.leave}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <span
+                      className={`inline-flex items-center justify-center px-2 h-6 rounded text-xs font-semibold ${
+                        isLowAttendance
+                          ? 'bg-red-200 text-red-800'
+                          : 'bg-green-100 text-green-700'
+                      }`}
+                    >
+                      {attendanceRate.toFixed(1)}%
+                    </span>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function AttendanceReportContent() {
+  const now = new Date()
+  const [selectedMonth, setSelectedMonth] = useState<number>(now.getMonth() + 1)
+  const [selectedYear, setSelectedYear] = useState<number>(now.getFullYear())
+  const [fetchParams, setFetchParams] = useState<{ month: number; year: number } | null>(null)
+
+  const { data, isPending, isError } = useMonthlyReport(
+    fetchParams?.month ?? selectedMonth,
+    fetchParams?.year ?? selectedYear,
+    fetchParams !== null,
+  )
+
+  const reportData: MonthlyReportData | null = data?.data ?? null
+
+  const handleFetch = () => {
+    setFetchParams({ month: selectedMonth, year: selectedYear })
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <BarChart3 aria-hidden="true" className="h-6 w-6 text-gray-700" />
+        <h1 className="text-2xl font-bold text-gray-900">Rekap Kehadiran Bulanan</h1>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-4">
+          <CardTitle className="text-base">Filter Periode</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-gray-700">Bulan</label>
+              <Select
+                value={String(selectedMonth)}
+                onValueChange={(v) => setSelectedMonth(Number(v))}
+              >
+                <SelectTrigger className="w-40">
+                  <SelectValue placeholder="Pilih bulan..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {MONTHS.map((m) => (
+                    <SelectItem key={m.value} value={String(m.value)}>
+                      {m.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-gray-700">Tahun</label>
+              <Select
+                value={String(selectedYear)}
+                onValueChange={(v) => setSelectedYear(Number(v))}
+              >
+                <SelectTrigger className="w-28">
+                  <SelectValue placeholder="Pilih tahun..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {YEARS.map((y) => (
+                    <SelectItem key={y} value={String(y)}>
+                      {y}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <Button onClick={handleFetch} disabled={isPending}>
+              {isPending && <Loader2 aria-hidden="true" className="h-4 w-4 mr-2 animate-spin" />}
+              Lihat Rekap
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {isPending && fetchParams !== null && (
+        <div className="flex items-center justify-center py-16 text-gray-500">
+          <Loader2 aria-hidden="true" className="h-6 w-6 animate-spin mr-3" />
+          <span>Memuat data rekap...</span>
+        </div>
+      )}
+
+      {isError && (
+        <div role="alert" className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          Gagal memuat data rekap. Pastikan Anda memiliki akses yang cukup.
+        </div>
+      )}
+
+      {!isPending && reportData && (
+        <Card>
+          <CardHeader className="pb-4">
+            <CardTitle className="text-base">
+              Rekap {MONTHS.find((m) => m.value === reportData.month)?.label} {reportData.year}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {reportData.employees.length === 0 ? (
+              <p className="text-sm text-gray-500 text-center py-8">
+                Tidak ada data karyawan untuk periode ini.
+              </p>
+            ) : (
+              <ReportTable data={reportData} />
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+export default function AttendanceReportPage() {
+  return (
+    <RoleGate
+      allowedRoles={['entity_admin', 'holding_admin', 'super_admin']}
+      fallback={
+        <div className="flex items-center justify-center py-24 text-gray-500">
+          <p>Anda tidak memiliki akses ke halaman ini.</p>
+        </div>
+      }
+    >
+      <AttendanceReportContent />
+    </RoleGate>
+  )
+}

--- a/frontend/src/app/(dashboard)/layout.tsx
+++ b/frontend/src/app/(dashboard)/layout.tsx
@@ -7,6 +7,7 @@ import {
   LayoutDashboard,
   Users,
   Clock,
+  ClipboardList,
   CalendarOff,
   Banknote,
   Settings,
@@ -33,6 +34,7 @@ const NAV_ITEMS: NavItem[] = [
   { href: '/overview', label: 'Overview', icon: LayoutDashboard, roles: null },
   { href: '/employees', label: 'Karyawan', icon: Users, roles: ['entity_admin', 'holding_admin', 'super_admin', 'manager'] },
   { href: '/attendance', label: 'Absensi', icon: Clock, roles: null },
+  { href: '/attendance/report', label: 'Rekap Bulanan', icon: ClipboardList, roles: ['entity_admin', 'holding_admin', 'super_admin'] },
   { href: '/leave', label: 'Cuti', icon: CalendarOff, roles: null },
   { href: '/payroll/runs', label: 'Payroll', icon: Banknote, roles: ['entity_admin', 'holding_admin', 'super_admin'] },
   { href: '/settings', label: 'Pengaturan', icon: Settings, roles: ['entity_admin', 'holding_admin', 'super_admin'] },
@@ -83,7 +85,10 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         {/* Nav */}
         <nav className="flex-1 px-3 py-4 space-y-0.5">
           {NAV_ITEMS.map((item) => {
-            const isActive = pathname === item.href || pathname.startsWith(item.href + '/')
+            // For /attendance, only match the exact path or sub-paths not claimed by other nav items
+            const isActive = pathname === item.href
+              || (pathname.startsWith(item.href + '/')
+                  && !NAV_ITEMS.some((other) => other.href !== item.href && pathname.startsWith(other.href)))
             const Icon = item.icon
 
             const link = (

--- a/frontend/src/lib/api/attendance.ts
+++ b/frontend/src/lib/api/attendance.ts
@@ -8,7 +8,21 @@ export const attendanceApi = {
     apiClient.post('/attendance/clock-out', data ?? {}),
   today: () => apiClient.get('/attendance/today'),
   list: (params?: Record<string, string>) => apiClient.get('/attendance', { params }),
+  monthlyReport: (month: number, year: number) =>
+    apiClient.get('/attendance/monthly-report', { params: { month, year } }),
 }
+
+export function getMonthlyReport(month: number, year: number) {
+  return apiClient.get('/attendance/monthly-report', { params: { month, year } })
+}
+
+export const useMonthlyReport = (month: number, year: number, enabled: boolean) =>
+  useQuery({
+    queryKey: ['attendance-monthly-report', month, year],
+    queryFn: () => attendanceApi.monthlyReport(month, year).then((r) => r.data),
+    enabled,
+    retry: false,
+  })
 
 export const useTodayAttendance = () =>
   useQuery({

--- a/frontend/src/lib/api/attendance.ts
+++ b/frontend/src/lib/api/attendance.ts
@@ -12,10 +12,6 @@ export const attendanceApi = {
     apiClient.get('/attendance/monthly-report', { params: { month, year } }),
 }
 
-export function getMonthlyReport(month: number, year: number) {
-  return apiClient.get('/attendance/monthly-report', { params: { month, year } })
-}
-
 export const useMonthlyReport = (month: number, year: number, enabled: boolean) =>
   useQuery({
     queryKey: ['attendance-monthly-report', month, year],


### PR DESCRIPTION
Closes #17

## Changes

### Backend
- `AttendanceController@monthlyReport`: `GET /api/attendance/monthly-report?month=&year=`
  - Menghitung hari kerja (Senin–Jumat) dalam bulan
  - Query semua employment aktif di entitas (entity-scoped via `active_entity_id`)
  - Per karyawan: hadir (PRESENT+LATE), terlambat (LATE), tidak hadir (ABSENT), cuti (APPROVED LeaveRequest)
  - Permission: `attendance.view_all`
- Route ditambahkan **sebelum** `/{attendance}/correct` untuk hindari route conflict
- Import `LeaveRequest` dan `Carbon` ditambahkan ke controller

### Frontend
- `/attendance/report` — halaman rekap bulanan
  - Filter dropdown bulan (1–12) dan tahun (2023–2026), tombol "Lihat Rekap"
  - Tabel: Nama, NIK, Posisi, Hadir, Terlambat, Tidak Hadir, Cuti, % Kehadiran
  - **Row merah** jika kehadiran < 80%
  - **Export CSV** langsung dari browser (generate di frontend)
  - Hanya tampil untuk `entity_admin`, `holding_admin`, `super_admin` (via RoleGate)
- `useMonthlyReport` hook (TanStack Query v5) + `getMonthlyReport` API function di `attendance.ts`
- Nav item **"Rekap Bulanan"** di sidebar, hanya visible untuk admin roles
  - Fixed active-state logic agar `/attendance` tidak ikut highlight saat di `/attendance/report`