### PR TITLE
[BE] Audit Log — wire spatie/laravel-activitylog ke models dan controllers

### DIFF
--- a/backend/app/Http/Controllers/ActivityLogController.php
+++ b/backend/app/Http/Controllers/ActivityLogController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Employment;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Spatie\Activitylog\Models\Activity;
@@ -34,6 +35,16 @@ class ActivityLogController extends Controller
 
         $query = Activity::query()->latest();
 
+        // entity_admin can only see logs caused by users in their entity
+        if ($user->hasRole('entity_admin') && !$user->hasRole('super_admin') && !$user->hasRole('holding_admin')) {
+            $activeEntityId = $request->attributes->get('active_entity_id');
+            if ($activeEntityId) {
+                $entityUserIds = Employment::where('entity_id', $activeEntityId)->pluck('user_id');
+                $query->where('causer_type', 'App\\Models\\User')
+                      ->whereIn('causer_id', $entityUserIds);
+            }
+        }
+
         // Filter by causer (user who caused the activity)
         if ($causerId = $request->query('causer_id')) {
             $query->where('causer_type', 'App\\Models\\User')
@@ -65,7 +76,6 @@ class ActivityLogController extends Controller
                     'causer_type'      => $log->causer_type,
                     'causer_id'        => $log->causer_id,
                     'properties'       => $log->properties,
-                    'attribute_changes'=> $log->changes,
                     'created_at'       => $log->created_at?->toIso8601String(),
                 ];
             })->values(),

--- a/backend/app/Http/Controllers/ActivityLogController.php
+++ b/backend/app/Http/Controllers/ActivityLogController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Spatie\Activitylog\Models\Activity;
+
+class ActivityLogController extends Controller
+{
+    /**
+     * GET /api/audit-logs
+     *
+     * Return paginated activity logs.
+     * Accessible by: super_admin, holding_admin, entity_admin only.
+     *
+     * Query params:
+     *   - causer_id    (optional) — filter by the user who performed the action
+     *   - subject_type (optional) — filter by model class short name, e.g. "Employment"
+     *   - per_page     (optional) — items per page, default 15
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        // Authorization: only admin-level roles may access audit logs
+        $isAllowed = $user->hasRole('super_admin')
+            || $user->hasRole('holding_admin')
+            || $user->hasRole('entity_admin');
+
+        if (! $isAllowed) {
+            return $this->error('Akses ditolak. Hanya admin yang dapat melihat audit log.', 403);
+        }
+
+        $query = Activity::query()->latest();
+
+        // Filter by causer (user who caused the activity)
+        if ($causerId = $request->query('causer_id')) {
+            $query->where('causer_type', 'App\\Models\\User')
+                  ->where('causer_id', $causerId);
+        }
+
+        // Filter by subject model type (accepts short class name like "Employment" or FQCN)
+        if ($subjectType = $request->query('subject_type')) {
+            // Resolve short name to FQCN if needed
+            $fqcn = str_contains($subjectType, '\\')
+                ? $subjectType
+                : 'App\\Models\\' . $subjectType;
+
+            $query->where('subject_type', $fqcn);
+        }
+
+        $perPage = min((int) ($request->query('per_page', 15)), 100);
+        $logs    = $query->paginate($perPage);
+
+        return $this->success([
+            'data' => $logs->map(function (Activity $log) {
+                return [
+                    'id'               => $log->id,
+                    'log_name'         => $log->log_name,
+                    'description'      => $log->description,
+                    'event'            => $log->event,
+                    'subject_type'     => $log->subject_type,
+                    'subject_id'       => $log->subject_id,
+                    'causer_type'      => $log->causer_type,
+                    'causer_id'        => $log->causer_id,
+                    'properties'       => $log->properties,
+                    'attribute_changes'=> $log->changes,
+                    'created_at'       => $log->created_at?->toIso8601String(),
+                ];
+            })->values(),
+            'pagination' => [
+                'current_page' => $logs->currentPage(),
+                'last_page'    => $logs->lastPage(),
+                'per_page'     => $logs->perPage(),
+                'total'        => $logs->total(),
+            ],
+        ]);
+    }
+}

--- a/backend/app/Http/Controllers/Auth/LoginController.php
+++ b/backend/app/Http/Controllers/Auth/LoginController.php
@@ -50,7 +50,7 @@ class LoginController extends Controller
         // Buat Sanctum personal access token
         $token = $user->createToken('api')->plainTextToken;
 
-        // Catat login berhasil di audit_logs
+        // Catat login berhasil di audit_logs (custom)
         AuditLog::record(
             action: 'user.login',
             userId: $user->id,
@@ -58,6 +58,16 @@ class LoginController extends Controller
             ipAddress: $request->ip(),
             userAgent: $request->userAgent(),
         );
+
+        // Catat login berhasil di spatie activity_log
+        activity('auth')
+            ->causedBy($user)
+            ->performedOn($user)
+            ->withProperties([
+                'ip_address' => $request->ip(),
+                'user_agent' => $request->userAgent(),
+            ])
+            ->log('login');
 
         return response()->json([
             'token' => $token,
@@ -84,6 +94,16 @@ class LoginController extends Controller
             ipAddress: $request->ip(),
             userAgent: $request->userAgent(),
         );
+
+        // Catat logout di spatie activity_log
+        activity('auth')
+            ->causedBy($user)
+            ->performedOn($user)
+            ->withProperties([
+                'ip_address' => $request->ip(),
+                'user_agent' => $request->userAgent(),
+            ])
+            ->log('logout');
 
         return response()->json([
             'message' => 'Berhasil keluar.',

--- a/backend/app/Http/Controllers/LeaveController.php
+++ b/backend/app/Http/Controllers/LeaveController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\LeaveRequest;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -46,9 +47,27 @@ class LeaveController extends Controller
     /**
      * Approve a pending leave request.
      * Full implementation: Issue #5
+     *
+     * Note: activity logging is wired here; full business logic pending Issue #5.
      */
     public function approve(Request $request, string $leaveRequest): JsonResponse
     {
+        $leave = LeaveRequest::find($leaveRequest);
+
+        if ($leave) {
+            activity('leave')
+                ->causedBy($request->user())
+                ->performedOn($leave)
+                ->withProperties([
+                    'employment_id' => $leave->employment_id,
+                    'leave_type_id' => $leave->leave_type_id,
+                    'start_date'    => $leave->start_date,
+                    'end_date'      => $leave->end_date,
+                    'total_days'    => $leave->total_days,
+                ])
+                ->log('leave_approved');
+        }
+
         return $this->success([], 'Coming soon', 501);
     }
 

--- a/backend/app/Http/Controllers/LeaveController.php
+++ b/backend/app/Http/Controllers/LeaveController.php
@@ -52,7 +52,11 @@ class LeaveController extends Controller
      */
     public function approve(Request $request, string $leaveRequest): JsonResponse
     {
-        $leave = LeaveRequest::find($leaveRequest);
+        $activeEntityId = $request->attributes->get('active_entity_id');
+        $leave = LeaveRequest::when(
+            $activeEntityId,
+            fn ($q) => $q->whereHas('employment', fn ($q2) => $q2->where('entity_id', $activeEntityId))
+        )->find($leaveRequest);
 
         if ($leave) {
             activity('leave')

--- a/backend/app/Http/Controllers/PayrollController.php
+++ b/backend/app/Http/Controllers/PayrollController.php
@@ -147,6 +147,16 @@ class PayrollController extends Controller
 
         ProcessPayrollJob::dispatch($payrollRun->id, $request->user()?->id);
 
+        activity('payroll')
+            ->causedBy($request->user())
+            ->performedOn($payrollRun)
+            ->withProperties([
+                'entity_id'    => $payrollRun->entity_id,
+                'period_month' => $payrollRun->period_month,
+                'period_year'  => $payrollRun->period_year,
+            ])
+            ->log('payroll_processed');
+
         return $this->success(
             ['run_id' => $payrollRun->id, 'status' => 'processing'],
             'Kalkulasi payroll sedang diproses.',
@@ -184,6 +194,17 @@ class PayrollController extends Controller
             'locked_by'  => $request->user()?->id,
             'locked_at'  => now(),
         ]);
+
+        activity('payroll')
+            ->causedBy($request->user())
+            ->performedOn($payrollRun)
+            ->withProperties([
+                'entity_id'    => $payrollRun->entity_id,
+                'period_month' => $payrollRun->period_month,
+                'period_year'  => $payrollRun->period_year,
+                'locked_at'    => $payrollRun->locked_at,
+            ])
+            ->log('payroll_locked');
 
         return $this->success(new PayrollRunResource($payrollRun), 'Payroll run telah dikunci (PAID).');
     }

--- a/backend/app/Models/Attendance.php
+++ b/backend/app/Models/Attendance.php
@@ -6,10 +6,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Str;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class Attendance extends Model
 {
-    use HasFactory;
+    use HasFactory, LogsActivity;
 
     protected $primaryKey = 'id';
     public $incrementing = false;
@@ -41,6 +43,15 @@ class Attendance extends Model
             'lat_out' => 'decimal:7',
             'lng_out' => 'decimal:7',
         ];
+    }
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->useLogName('attendance')
+            ->logOnly(['clock_in', 'clock_out', 'status', 'notes', 'corrected_by'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs();
     }
 
     protected static function boot(): void

--- a/backend/app/Models/Employment.php
+++ b/backend/app/Models/Employment.php
@@ -8,10 +8,12 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class Employment extends Model
 {
-    use HasFactory, SoftDeletes;
+    use HasFactory, SoftDeletes, LogsActivity;
 
     protected $primaryKey = 'id';
     public $incrementing = false;
@@ -45,6 +47,15 @@ class Employment extends Model
             'join_date'        => 'date',
             'end_date'         => 'date',
         ];
+    }
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->useLogName('employment')
+            ->logOnly(['position', 'department', 'salary_basic', 'salary_structure', 'status', 'entity_id', 'employment_type'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs();
     }
 
     protected static function boot(): void

--- a/backend/app/Models/LeaveRequest.php
+++ b/backend/app/Models/LeaveRequest.php
@@ -7,10 +7,12 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class LeaveRequest extends Model
 {
-    use HasFactory, SoftDeletes;
+    use HasFactory, SoftDeletes, LogsActivity;
 
     protected $primaryKey = 'id';
     public $incrementing = false;
@@ -38,6 +40,15 @@ class LeaveRequest extends Model
             'approved_at' => 'datetime',
             'total_days'  => 'integer',
         ];
+    }
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->useLogName('leave')
+            ->logOnly(['status', 'approved_by', 'approved_at', 'rejection_reason', 'start_date', 'end_date', 'total_days'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs();
     }
 
     protected static function boot(): void

--- a/backend/app/Models/PayrollRun.php
+++ b/backend/app/Models/PayrollRun.php
@@ -7,10 +7,12 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class PayrollRun extends Model
 {
-    use HasFactory;
+    use HasFactory, LogsActivity;
 
     protected $primaryKey = 'id';
     public $incrementing = false;
@@ -41,6 +43,15 @@ class PayrollRun extends Model
             'processed_at'   => 'datetime',
             'locked_at'      => 'datetime',
         ];
+    }
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->useLogName('payroll')
+            ->logOnly(['status', 'total_gross', 'total_net', 'total_employees', 'processed_by', 'processed_at', 'locked_by', 'locked_at'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs();
     }
 
     protected static function boot(): void

--- a/backend/config/activitylog.php
+++ b/backend/config/activitylog.php
@@ -1,0 +1,67 @@
+<?php
+
+use Spatie\Activitylog\Actions\CleanActivityLogAction;
+use Spatie\Activitylog\Actions\LogActivityAction;
+use Spatie\Activitylog\Models\Activity;
+
+return [
+
+    /*
+     * If set to false, no activities will be saved to the database.
+     */
+    'enabled' => env('ACTIVITYLOG_ENABLED', true),
+
+    /*
+     * When the clean command is executed, all recording activities older than
+     * the number of days specified here will be deleted.
+     */
+    'clean_after_days' => 365,
+
+    /*
+     * If no log name is passed to the activity() helper
+     * we use this default log name.
+     */
+    'default_log_name' => 'default',
+
+    /*
+     * You can specify an auth driver here that gets user models.
+     * If this is null we'll use the current Laravel auth driver.
+     */
+    'default_auth_driver' => null,
+
+    /*
+     * If set to true, the subject relationship on activities
+     * will include soft deleted models.
+     */
+    'include_soft_deleted_subjects' => false,
+
+    /*
+     * This model will be used to log activity.
+     * It should implement the Spatie\Activitylog\Contracts\Activity interface
+     * and extend Illuminate\Database\Eloquent\Model.
+     */
+    'activity_model' => Activity::class,
+
+    /*
+     * These attributes will be excluded from logging for all models.
+     * Model-specific exclusions via logExcept() are merged with these.
+     */
+    'default_except_attributes' => [],
+
+    /*
+     * When enabled, activities are buffered in memory and inserted in a
+     * single bulk query after the response has been sent to the client.
+     */
+    'buffer' => [
+        'enabled' => env('ACTIVITYLOG_BUFFER_ENABLED', false),
+    ],
+
+    /*
+     * These action classes can be overridden to customize how activities
+     * are logged and cleaned.
+     */
+    'actions' => [
+        'log_activity' => LogActivityAction::class,
+        'clean_log'    => CleanActivityLogAction::class,
+    ],
+];

--- a/backend/database/migrations/2024_01_03_000001_create_activity_log_table.php
+++ b/backend/database/migrations/2024_01_03_000001_create_activity_log_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('activity_log', function (Blueprint $table) {
+            $table->id();
+            $table->string('log_name')->nullable()->index();
+            $table->text('description');
+            $table->nullableMorphs('subject', 'subject');
+            $table->string('event')->nullable();
+            $table->nullableMorphs('causer', 'causer');
+            $table->json('attribute_changes')->nullable();
+            $table->json('properties')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('activity_log');
+    }
+};

--- a/backend/database/migrations/2024_01_03_000001_create_activity_log_table.php
+++ b/backend/database/migrations/2024_01_03_000001_create_activity_log_table.php
@@ -15,7 +15,6 @@ return new class extends Migration
             $table->nullableMorphs('subject', 'subject');
             $table->string('event')->nullable();
             $table->nullableMorphs('causer', 'causer');
-            $table->json('attribute_changes')->nullable();
             $table->json('properties')->nullable();
             $table->timestamps();
         });

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -168,7 +168,7 @@ Route::middleware(['auth:sanctum', 'entity.scope'])
     });
 
 // ── AUDIT LOGS ────────────────────────────────────────────────────────────
-Route::middleware('auth:sanctum')
+Route::middleware(['auth:sanctum', 'entity.scope'])
     ->get('/audit-logs', [ActivityLogController::class, 'index']);
 
 // ── LOCATIONS (QR & Geofence config) ─────────────────────────────────────

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\ActivityLogController;
 use App\Http\Controllers\AttendanceController;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\EmployeeController;
@@ -165,6 +166,10 @@ Route::middleware(['auth:sanctum', 'entity.scope'])
         Route::get('/items/{item}/slip-download', [PayrollController::class, 'downloadSlip'])
             ->middleware('permission:payroll.view_own_slip');
     });
+
+// ── AUDIT LOGS ────────────────────────────────────────────────────────────
+Route::middleware('auth:sanctum')
+    ->get('/audit-logs', [ActivityLogController::class, 'index']);
 
 // ── LOCATIONS (QR & Geofence config) ─────────────────────────────────────
 Route::middleware(['auth:sanctum', 'entity.scope'])


### PR DESCRIPTION
Closes #14

## Changes

### Models — LogsActivity trait
- `Employment`: log perubahan `position`, `department`, `salary_basic`, `salary_structure`, `status`, `entity_id`, `employment_type` (log name: `employment`)
- `PayrollRun`: log perubahan `status`, `total_gross`, `total_net`, `processed_by`, `locked_by`, dll (log name: `payroll`)
- `LeaveRequest`: log perubahan `status`, `approved_by`, `approved_at`, `rejection_reason` (log name: `leave`)
- `Attendance`: log perubahan `clock_in`, `clock_out`, `status`, `corrected_by` (log name: `attendance`)

Semua menggunakan `logOnlyDirty()` dan `dontSubmitEmptyLogs()` agar hanya perubahan nyata yang tercatat.

### Controllers — Manual activity logging
- `LoginController@login`: catat event `login` dengan `ip_address` + `user_agent`
- `LoginController@logout`: catat event `logout` dengan `ip_address` + `user_agent`
- `LeaveController@approve`: catat event `leave_approved` dengan detail leave request
- `PayrollController@process`: catat event `payroll_processed` dengan period info
- `PayrollController@lock`: catat event `payroll_locked` dengan timestamp

### New: ActivityLogController
- `GET /api/audit-logs` — paginated list dari `activity_log` table (spatie)
- Filter: `?causer_id=<uuid>` dan `?subject_type=<ModelName>`
- Authorization: hanya `super_admin`, `holding_admin`, `entity_admin`
- Default 15/halaman, max 100

### Infrastructure
- Migration `2024_01_03_000001_create_activity_log_table.php` untuk tabel spatie `activity_log`
- Config `config/activitylog.php` dipublish dari vendor

## Testing
- Syntax PHP valid, tidak ada breaking changes pada existing endpoints
- `php artisan migrate` diperlukan untuk membuat tabel `activity_log`