### PR TITLE
[BE] Document Management — upload/download dokumen karyawan

### DIFF
--- a/backend/app/Http/Controllers/DocumentController.php
+++ b/backend/app/Http/Controllers/DocumentController.php
@@ -81,8 +81,13 @@ class DocumentController extends Controller
     public function download(Request $request, string $employmentId, string $documentId): StreamedResponse|JsonResponse
     {
         $employment = Employment::findOrFail($employmentId);
-        $doc        = Document::where('employment_id', $employmentId)->findOrFail($documentId);
 
+        $activeEntityId = $request->attributes->get('active_entity_id');
+        if ($activeEntityId && $employment->entity_id !== $activeEntityId) {
+            return $this->error('Akses ditolak.', 403);
+        }
+
+        $doc     = Document::where('employment_id', $employmentId)->findOrFail($documentId);
         $user    = $request->user();
         $isOwner = $employment->user_id === $user->id;
         $isAdmin = $user->hasRole('super_admin') || $user->hasRole('holding_admin')

--- a/backend/app/Http/Controllers/DocumentController.php
+++ b/backend/app/Http/Controllers/DocumentController.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Document;
+use App\Models\Employment;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class DocumentController extends Controller
+{
+    public function index(Request $request, string $employmentId): JsonResponse
+    {
+        $employment = Employment::findOrFail($employmentId);
+
+        $activeEntityId = $request->attributes->get('active_entity_id');
+        if ($activeEntityId && $employment->entity_id !== $activeEntityId) {
+            return $this->error('Akses ditolak.', 403);
+        }
+
+        $docs = Document::where('employment_id', $employmentId)
+            ->with('uploadedBy:id,name')
+            ->orderBy('created_at', 'desc')
+            ->get()
+            ->map(fn ($doc) => [
+                'id'          => $doc->id,
+                'type'        => $doc->type,
+                'label'       => $doc->label,
+                'expires_at'  => $doc->expires_at?->toDateString(),
+                'uploaded_by' => $doc->uploadedBy?->only(['id', 'name']),
+                'created_at'  => $doc->created_at,
+            ]);
+
+        return $this->success($docs);
+    }
+
+    public function store(Request $request, string $employmentId): JsonResponse
+    {
+        $employment = Employment::findOrFail($employmentId);
+
+        $activeEntityId = $request->attributes->get('active_entity_id');
+        if ($activeEntityId && $employment->entity_id !== $activeEntityId) {
+            return $this->error('Akses ditolak.', 403);
+        }
+
+        $validated = $request->validate([
+            'type'       => 'required|in:KTP,NPWP,IJAZAH,SK_PENGANGKATAN,KONTRAK,SERTIFIKAT,LAINNYA',
+            'label'      => 'nullable|string|max:255',
+            'expires_at' => 'nullable|date',
+            'file'       => 'required|file|mimes:pdf,jpg,jpeg,png|max:5120',
+        ]);
+
+        $file      = $request->file('file');
+        $ext       = $file->getClientOriginalExtension();
+        $storedId  = (string) Str::uuid();
+        $path      = $file->storeAs("documents/{$employmentId}", "{$storedId}.{$ext}", 'local');
+
+        $label = $validated['label'] ?? $file->getClientOriginalName();
+
+        $doc = Document::create([
+            'employment_id' => $employmentId,
+            'type'          => $validated['type'],
+            'label'         => $label,
+            'file_url'      => $path,
+            'expires_at'    => $validated['expires_at'] ?? null,
+            'uploaded_by'   => $request->user()->id,
+        ]);
+
+        return $this->success([
+            'id'         => $doc->id,
+            'type'       => $doc->type,
+            'label'      => $doc->label,
+            'expires_at' => $doc->expires_at?->toDateString(),
+            'created_at' => $doc->created_at,
+        ], 'Dokumen berhasil diupload.', 201);
+    }
+
+    public function download(Request $request, string $employmentId, string $documentId): StreamedResponse|JsonResponse
+    {
+        $employment = Employment::findOrFail($employmentId);
+        $doc        = Document::where('employment_id', $employmentId)->findOrFail($documentId);
+
+        $user    = $request->user();
+        $isOwner = $employment->user_id === $user->id;
+        $isAdmin = $user->hasRole('super_admin') || $user->hasRole('holding_admin')
+                || $user->hasRole('entity_admin') || $user->hasRole('manager');
+
+        if (!$isOwner && !$isAdmin) {
+            return $this->error('Akses ditolak.', 403);
+        }
+
+        $path = $doc->file_url;
+
+        if (str_contains($path, '..') || str_contains($path, "\0")) {
+            return $this->error('Path tidak valid.', 400);
+        }
+
+        if (!Storage::disk('local')->exists($path)) {
+            return $this->error('File tidak ditemukan.', 404);
+        }
+
+        return Storage::disk('local')->download($path, $doc->label ?? basename($path));
+    }
+
+    public function destroy(Request $request, string $employmentId, string $documentId): JsonResponse
+    {
+        $employment = Employment::findOrFail($employmentId);
+
+        $activeEntityId = $request->attributes->get('active_entity_id');
+        if ($activeEntityId && $employment->entity_id !== $activeEntityId) {
+            return $this->error('Akses ditolak.', 403);
+        }
+
+        $doc = Document::where('employment_id', $employmentId)->findOrFail($documentId);
+
+        Storage::disk('local')->delete($doc->file_url);
+        $doc->delete();
+
+        return $this->success(null, 'Dokumen berhasil dihapus.');
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ActivityLogController;
 use App\Http\Controllers\AttendanceController;
 use App\Http\Controllers\Auth\LoginController;
+use App\Http\Controllers\DocumentController;
 use App\Http\Controllers\EmployeeController;
 use App\Http\Controllers\EntityController;
 use App\Http\Controllers\LeaveController;
@@ -177,6 +178,23 @@ Route::middleware(['auth:sanctum', 'entity.scope'])
 // ── AUDIT LOGS ────────────────────────────────────────────────────────────
 Route::middleware(['auth:sanctum', 'entity.scope'])
     ->get('/audit-logs', [ActivityLogController::class, 'index']);
+
+// ── DOCUMENTS ────────────────────────────────────────────────────────────
+Route::middleware(['auth:sanctum', 'entity.scope'])
+    ->prefix('employees/{employment}/documents')
+    ->group(function () {
+        Route::get('/', [DocumentController::class, 'index'])
+            ->middleware('permission:employees.view');
+
+        Route::post('/', [DocumentController::class, 'store'])
+            ->middleware('permission:employees.update');
+
+        Route::get('/{document}/download', [DocumentController::class, 'download'])
+            ->middleware('permission:employees.view');
+
+        Route::delete('/{document}', [DocumentController::class, 'destroy'])
+            ->middleware('permission:employees.update');
+    });
 
 // ── LOCATIONS (QR & Geofence config) ─────────────────────────────────────
 Route::middleware(['auth:sanctum', 'entity.scope'])


### PR DESCRIPTION
Closes #15

## Changes
- `DocumentController`: index (list per employment), store (upload), download (stream securely), destroy (delete file + record)
- Routes: `GET/POST /api/employees/{employment}/documents`, `GET /documents/{document}/download`, `DELETE /documents/{document}`
- Reuses existing `Document` model + migration (`000009_create_documents_table`)
- Employment model relationship `documents()` was already wired to `Document::class`

## Validation & Security
- File types: pdf, jpg, jpeg, png — max 5MB
- Entity scope guard on all write operations (`entity_id` check)
- Download guard: employment owner OR role manager/entity_admin/holding_admin/super_admin
- Path traversal protection (`..` and null-byte check) on download
- `file_url` (storage path) is not exposed in list/show responses
- Files stored at `storage/app/documents/{employment_id}/{uuid}.ext`

🤖 Generated with Claude Code